### PR TITLE
allow multiple reusable toasts

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,28 +3,44 @@
 import * as React from "react";
 import * as Toast from "@radix-ui/react-toast";
 
-import { Button } from "@/components/Button";
+import { ThemeSwitch } from "@/components/theme/ThemeSwitch";
 import { InfoCircleIcon } from "@/components/icon/base/InfoCircleIcon";
-import { InfoToast } from "@/components/toast/InfoToast";
+import { ErrorToast, InfoToast, SuccessToast, ToastRoot } from "@/components/toast/InfoToast";
 
 export default function Home() {
-  const [open, setOpen] = React.useState<number>(0);
+  const a = ErrorToast();
+  const b = InfoToast();
+  const c = SuccessToast();
 
   return (
-    <Toast.Provider swipeDirection="right">
+    <Toast.Provider duration={10 * 1000} swipeDirection="right">
       <main className="flex min-h-screen flex-col items-center justify-between p-24 bg-white text-black dark:bg-black dark:text-white">
         <div className="w-full max-w-5xl items-center justify-between text-sm">
 
           hello world
-          <Button />
+          <ThemeSwitch />
 
           <button onClick={() => {
-            setOpen(open => open + 1);
+            a.new("something's wrong");
           }}>
             <InfoCircleIcon />
           </button>
-          <InfoToast key={open} />
 
+          <button onClick={() => {
+            b.new("you should read this");
+          }}>
+            <InfoCircleIcon />
+          </button>
+
+          <button onClick={() => {
+            c.new("this is great");
+          }}>
+            <InfoCircleIcon />
+          </button>
+
+          <ToastRoot ref={a.ref()} />
+          <ToastRoot ref={b.ref()} />
+          <ToastRoot ref={c.ref()} />
 
           <Toast.Viewport className="[--viewport-padding:_25px] fixed bottom-0 right-0 flex flex-col p-[var(--viewport-padding)] gap-[10px] w-[390px] max-w-[100vw] m-0 list-none z-[2147483647] outline-none" />
         </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,7 +5,7 @@ import * as Toast from "@radix-ui/react-toast";
 
 import { ThemeSwitch } from "@/components/theme/ThemeSwitch";
 import { InfoCircleIcon } from "@/components/icon/base/InfoCircleIcon";
-import { ErrorToast, InfoToast, SuccessToast, ToastRoot } from "@/components/toast/InfoToast";
+import { ErrorToast, InfoToast, SuccessToast, ToastRoot } from "@/components/toast/Toast";
 
 export default function Home() {
   const err = ErrorToast();

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,9 +8,9 @@ import { InfoCircleIcon } from "@/components/icon/base/InfoCircleIcon";
 import { ErrorToast, InfoToast, SuccessToast, ToastRoot } from "@/components/toast/InfoToast";
 
 export default function Home() {
-  const a = ErrorToast();
-  const b = InfoToast();
-  const c = SuccessToast();
+  const err = ErrorToast();
+  const inf = InfoToast();
+  const suc = SuccessToast();
 
   return (
     <Toast.Provider duration={10 * 1000} swipeDirection="right">
@@ -21,26 +21,26 @@ export default function Home() {
           <ThemeSwitch />
 
           <button onClick={() => {
-            a.new("something's wrong");
+            err.new("something's wrong");
           }}>
             <InfoCircleIcon />
           </button>
 
           <button onClick={() => {
-            b.new("you should read this");
+            inf.new("you should read this");
           }}>
             <InfoCircleIcon />
           </button>
 
           <button onClick={() => {
-            c.new("this is great");
+            suc.new("this is great");
           }}>
             <InfoCircleIcon />
           </button>
 
-          <ToastRoot ref={a.ref()} />
-          <ToastRoot ref={b.ref()} />
-          <ToastRoot ref={c.ref()} />
+          <ToastRoot ref={err.ref()} />
+          <ToastRoot ref={inf.ref()} />
+          <ToastRoot ref={suc.ref()} />
 
           <Toast.Viewport className="[--viewport-padding:_25px] fixed bottom-0 right-0 flex flex-col p-[var(--viewport-padding)] gap-[10px] w-[390px] max-w-[100vw] m-0 list-none z-[2147483647] outline-none" />
         </div>

--- a/components/icon/base/XMarkIcon.tsx
+++ b/components/icon/base/XMarkIcon.tsx
@@ -1,0 +1,17 @@
+import { BaseIcon } from "@/components/icon/BaseIcon";
+
+interface Props {
+  className?: string;
+}
+
+export const XMarkIcon = (props: Props) => {
+  return (
+    <BaseIcon
+      className={props.className}
+    >
+      <g>
+        <path fill="currentColor" clipRule="evenodd" fillRule="evenodd" d="M5.47 5.47a.75.75 0 011.06 0L12 10.94l5.47-5.47a.75.75 0 111.06 1.06L13.06 12l5.47 5.47a.75.75 0 11-1.06 1.06L12 13.06l-5.47 5.47a.75.75 0 01-1.06-1.06L10.94 12 5.47 6.53a.75.75 0 010-1.06z" />
+      </g>
+    </BaseIcon>
+  );
+};

--- a/components/theme/ThemeSwitch.tsx
+++ b/components/theme/ThemeSwitch.tsx
@@ -14,7 +14,7 @@ const thmDrk = "dark";
 
 interface Props { }
 
-export const Button = (props: Props) => {
+export const ThemeSwitch = (props: Props) => {
   const [syst, setSyst] = React.useState<string>(getThm());
   const [them, setThem] = React.useState<string>(getThm());
 

--- a/components/toast/InfoToast.tsx
+++ b/components/toast/InfoToast.tsx
@@ -1,18 +1,123 @@
+import * as React from "react";
+
 import * as Toast from "@radix-ui/react-toast";
 
-interface Props { }
+import { XMarkIcon } from "@/components/icon/base/XMarkIcon";
 
-export const InfoToast = (props: Props) => {
-  return (
-    <Toast.Root
-      className="p-4 bg-yellow-300 text-black rounded-md items-center data-[state=open]:animate-slideIn data-[state=closed]:animate-hide data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=cancel]:translate-x-0 data-[swipe=cancel]:transition-[transform_200ms_ease-out] data-[swipe=end]:animate-swipeOut"
-    >
-      <Toast.Title className="font-medium">
-        Toast Title
-      </Toast.Title>
-      <Toast.Description>
-        foo bar toast description
-      </Toast.Description>
-    </Toast.Root>
-  );
+interface ToastBodyProps {
+  clss: string;
+  titl: string;
+}
+
+interface ToastRootData {
+  clss: string;
+  text: string;
+  titl: string;
+}
+
+interface ToastRootState {
+  dict: Map<number, ToastRootData>;
+  size: number;
+}
+
+export class ToastRoot extends React.Component<{}, ToastRootState> {
+  constructor(props: {}) {
+    super(props);
+
+    this.state = {
+      dict: new Map(),
+      size: 0,
+    };
+  }
+
+  new(data: ToastRootData): void {
+    this.setState((old) => {
+      return {
+        dict: old.dict.set(old.size + 1, data),
+        size: old.size + 1,
+      };
+    });
+  }
+
+  render() {
+    return (
+      <>
+        {[...this.state.dict.entries()].map(([key, val]) => (
+          <Toast.Root
+            key={key}
+            className={`
+              p-4
+              text-black rounded-md items-center
+              data-[state=open]:animate-slideIn data-[state=closed]:animate-hide data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=cancel]:translate-x-0 data-[swipe=cancel]:transition-[transform_200ms_ease-out] data-[swipe=end]:animate-swipeOut
+              ${val.clss}
+            `}
+            onOpenChange={(open: boolean) => {
+              if (open === false) {
+                this.state.dict.delete(key);
+              }
+            }}
+          >
+            <Toast.Title className="relative font-medium">
+              {val.titl}
+              <Toast.Close className="float-right" aria-label="Close">
+                <span className="text-gray-600 hover:text-gray-900">
+                  <XMarkIcon />
+                </span>
+              </Toast.Close>
+            </Toast.Title>
+            <Toast.Description>
+              {val.text}
+            </Toast.Description>
+          </Toast.Root>
+        ))}
+      </>
+    );
+  }
+};
+
+export class ToastBody extends React.Component<ToastBodyProps> {
+  private reference: React.RefObject<ToastRoot>;
+
+  constructor(props: ToastBodyProps) {
+    super(props);
+
+    this.reference = React.useRef<ToastRoot>(new ToastRoot({}));
+  }
+
+  ref(): React.RefObject<ToastRoot> {
+    return this.reference;
+  }
+
+  new(text: string): void {
+    this.reference.current?.new({
+      clss: this.props.clss,
+      text: text,
+      titl: this.props.titl,
+    });
+  }
+
+  render() {
+    return this.reference.current?.render();
+  }
+};
+
+export const ErrorToast = (): ToastBody => {
+  return new ToastBody({
+    clss: "bg-red-500",
+    titl: "Error",
+  });
+};
+
+export const InfoToast = (): ToastBody => {
+  return new ToastBody({
+    clss: "bg-yellow-300",
+    titl: "Info",
+  });
+};
+
+export const SuccessToast = (): ToastBody => {
+  return new ToastBody({
+    clss: "bg-green-500",
+    titl: "Success",
+  });
 };

--- a/components/toast/InfoToast.tsx
+++ b/components/toast/InfoToast.tsx
@@ -20,6 +20,17 @@ interface ToastRootState {
   size: number;
 }
 
+// ToastRoot needs to be mounted in some react component using the reference of
+// a toast object.
+//
+//     const err = ErrorToast();
+//     <ToastRoot ref={err.ref()} />
+//
+// Once the ToastRoot component is setup, the toast object can be used in the
+// local scope to emit a toast message.
+//
+//     err.new("something's wrong");
+//
 export class ToastRoot extends React.Component<{}, ToastRootState> {
   constructor(props: {}) {
     super(props);
@@ -75,13 +86,17 @@ export class ToastRoot extends React.Component<{}, ToastRootState> {
   }
 };
 
+// ToastBody is a react component that we only use to wrap some super annoying
+// workaround to make the currently used toast design work. The wrapped react
+// component is ToastRoot, which is used in any given local scope in which toast
+// messages are used to provide feedback about site interactions.
 export class ToastBody extends React.Component<ToastBodyProps> {
   private reference: React.RefObject<ToastRoot>;
 
   constructor(props: ToastBodyProps) {
     super(props);
 
-    this.reference = React.useRef<ToastRoot>(new ToastRoot({}));
+    this.reference = React.createRef<ToastRoot>();
   }
 
   ref(): React.RefObject<ToastRoot> {

--- a/components/toast/Interface.tsx
+++ b/components/toast/Interface.tsx
@@ -1,0 +1,15 @@
+export interface ToastBodyProps {
+  clss: string;
+  titl: string;
+};
+
+export interface ToastRootData {
+  clss: string;
+  text: string;
+  titl: string;
+};
+
+export interface ToastRootState {
+  dict: Map<number, ToastRootData>;
+  size: number;
+};

--- a/components/toast/Toast.tsx
+++ b/components/toast/Toast.tsx
@@ -3,22 +3,7 @@ import * as React from "react";
 import * as Toast from "@radix-ui/react-toast";
 
 import { XMarkIcon } from "@/components/icon/base/XMarkIcon";
-
-interface ToastBodyProps {
-  clss: string;
-  titl: string;
-}
-
-interface ToastRootData {
-  clss: string;
-  text: string;
-  titl: string;
-}
-
-interface ToastRootState {
-  dict: Map<number, ToastRootData>;
-  size: number;
-}
+import { ToastBodyProps, ToastRootData, ToastRootState } from "@/components/toast/Interface";
 
 // ToastRoot needs to be mounted in some react component using the reference of
 // a toast object.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,12 @@
 {
   "compilerOptions": {
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "target": "es2015",
+    "downlevelIteration": true,
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -18,9 +24,18 @@
       }
     ],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": [
+        "./*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
This change allows to stack multiple toasts anywhere. The idea here is to use toasts where they are needed without having to wrap and re-render the whole app on user notifications. The toasts disappear after 10 seconds, and can be removed earlier with the X button or the ESC key.

---

<img width="465" alt="Screenshot 2024-07-22 at 17 08 37" src="https://github.com/user-attachments/assets/0f6546de-930e-4a31-ad68-895017dcbb97">

---

<img width="500" alt="Screenshot 2024-07-22 at 17 08 50" src="https://github.com/user-attachments/assets/7f785462-d126-4435-b9b8-33f8f45e4b85">
