### PR TITLE
use generic auth page in page layout

### DIFF
--- a/app/claim/create/layout.tsx
+++ b/app/claim/create/layout.tsx
@@ -1,0 +1,9 @@
+import { AuthPage } from "@/components/auth/AuthPage";
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <AuthPage>
+      {children}
+    </AuthPage >
+  );
+};

--- a/app/claim/create/page.tsx
+++ b/app/claim/create/page.tsx
@@ -2,7 +2,6 @@
 
 import * as React from "react";
 
-// import { AuthPage } from "@/components/auth/AuthPage"; // TODO
 import { EditorButton } from "@/components/app/claim/create/editor/EditorButton";
 import { ExpiryField } from "@/components/app/claim/create/field/ExpiryField";
 import { LabelsField } from "@/components/app/claim/create/field/LabelsField";

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,11 +1,15 @@
-"use client";
-
 import "@/app/globals.css";
 
-import { Inter } from "next/font/google";
 import { AppProvider } from "@/components/app/AppProvider";
+import { Inter } from "next/font/google";
+import { Metadata } from "next";
 
 const inter = Inter({ subsets: ["latin"] });
+
+export const metadata: Metadata = {
+  title: "Uvio Network",
+  description: "The Social Network For Prediction Markets",
+}
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (

--- a/components/app/AppProvider.tsx
+++ b/components/app/AppProvider.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import * as Config from "@/modules/config";
 
 import { AuthProvider } from "@/components/auth/AuthProvider";

--- a/components/auth/AuthPage.tsx
+++ b/components/auth/AuthPage.tsx
@@ -1,16 +1,17 @@
-// TODO
-// "use client";
+"use client";
 
-// import * as Privy from "@privy-io/react-auth";
-// import * as React from "react";
+import * as Privy from "@privy-io/react-auth";
+import * as React from "react";
 
-// export const AuthPage = (Component: React.ComponentType) => {
-//   return (props: any) => {
-//     const { authenticated, login, ready } = Privy.usePrivy();
+export const AuthPage = ({ children }: { children: React.ReactNode }) => {
+  const { authenticated, ready } = Privy.usePrivy();
 
-//     if (!ready) return <></>;
-//     if (!authenticated) return login();
+  if (!ready) return <></>;
+  if (!authenticated) return <>You need to login to see this page.</>;
 
-//     return <Component {...props} />;
-//   };
-// };
+  return (
+    <>
+      {children}
+    </>
+  );
+};

--- a/components/sidebar/Sidebar.tsx
+++ b/components/sidebar/Sidebar.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import * as React from "react";
 import * as Separator from "@/components/sidebar/layout/separator";
 

--- a/components/sidebar/button/ProposeButton.tsx
+++ b/components/sidebar/button/ProposeButton.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import * as ToastSender from "@/components/toast/ToastSender";
 
 import { AuthStore } from "@/components/auth/AuthStore";
@@ -7,6 +9,7 @@ import { useRouter } from "next/navigation";
 
 export const ProposeButton = () => {
   const { auth } = AuthStore();
+
   const router = useRouter();
 
   const onClick = () => {


### PR DESCRIPTION
With that it should be possible to wrap any page with the provided auth page in order to make sure that only logged in users can see and interact with the requested page. I know this is usually done with the nextjs specific auth packages, but our auth using the Privy SDK is a bit out of band. It might be that Privy integrates with nextjs auth seemlessly. We can look more into this. For now the current approach works to move on.