### PR TITLE
implement inline modal for staking reputation

### DIFF
--- a/app/claim/tree/[slug]/page.tsx
+++ b/app/claim/tree/[slug]/page.tsx
@@ -1,3 +1,5 @@
+import * as Separator from "@/components/layout/separator";
+
 import { ClaimContainer } from "@/components/claim/ClaimContainer";
 import { ClaimObject } from "@/modules/claim/object/ClaimObject";
 import { PageHeader } from "@/components/page/PageHeader";
@@ -63,7 +65,12 @@ export default function Page({ params }: { params: { slug: string } }) {
       <PageHeader titl="Claim Tree" />
 
       {list.map((x: ClaimObject) => (
-        <ClaimContainer key={x.id()} claim={x} />
+        <>
+          <ClaimContainer key={x.id()} claim={x} />
+          <div className="w-full h-12 mb-8">
+            <Separator.Vertical />
+          </div>
+        </>
       ))}
     </>
   );

--- a/app/claim/tree/[slug]/page.tsx
+++ b/app/claim/tree/[slug]/page.tsx
@@ -64,12 +64,19 @@ export default function Page({ params }: { params: { slug: string } }) {
     <>
       <PageHeader titl="Claim Tree" />
 
-      {list.map((x: ClaimObject) => (
+      {list.map((x: ClaimObject, i: number) => (
         <>
           <ClaimContainer key={x.id()} claim={x} />
-          <div className="w-full h-12 mb-8">
-            <Separator.Vertical />
-          </div>
+
+          {/*
+          Show a vertical separator between claims and make sure that the last
+          claim does not display a separator anymore.
+          */}
+          {i < list.length - 1 && (
+            <div className="w-full h-12 mb-8">
+              <Separator.Vertical />
+            </div>
+          )}
         </>
       ))}
     </>

--- a/app/globals.css
+++ b/app/globals.css
@@ -8,26 +8,52 @@
   }
 }
 
+/* font */
+
+.dark {
+  color: white;
+}
+
+.light {
+  color: black;
+}
+
 /* background */
 
 .dark .background {
   background-color: black;
-  color: white;
 }
 
 .light .background {
   background-color: white;
-  color: black;
+}
+
+.dark .background-overlay {
+  /* gray-900 */
+  background-color: #111827;
+}
+
+.light .background-overlay {
+  /* gray-50 */
+  background-color: #f9fafb;
 }
 
 /* border */
 
-.light .border-color {
-  /* gray-200 */
-  border-color: #e5e7eb;
+.dark .border-background {
+  border-color: black;
+}
+
+.light .border-background {
+  border-color: white;
 }
 
 .dark .border-color {
   /* gray-700 */
   border-color: #374151;
+}
+
+.light .border-color {
+  /* gray-200 */
+  border-color: #e5e7eb;
 }

--- a/components/button/BaseButton.tsx
+++ b/components/button/BaseButton.tsx
@@ -3,10 +3,11 @@ import * as React from "react";
 interface Props {
   disabled?: boolean;
   font?: string;
+  hover?: string;
   onClick?: (eve: React.MouseEvent<HTMLButtonElement>) => void;
   position?: string;
   icon: React.ReactElement;
-  text: string;
+  text?: string;
 }
 
 export const BaseButton = (props: Props) => {
@@ -14,24 +15,23 @@ export const BaseButton = (props: Props) => {
     <button
       className={`
         flex p-2 w-full h-fit items-center rounded-lg outline-none group
-        text-gray-400 dark:text-gray-500
+        text-sm sm:text-base text-gray-400 dark:text-gray-500 whitespace-nowrap
         ${props.font ? props.font : "font-medium"}
-        ${props.disabled ? "opacity-50" : "enabled:hover:text-black enabled:dark:hover:text-white enabled:hover:bg-gray-200 enabled:dark:hover:bg-gray-700"}
-      `}
+        ${props.disabled ? "opacity-50" : props.hover ? props.hover : "enabled:hover:text-black enabled:dark:hover:text-white enabled:hover:bg-gray-200 enabled:dark:hover:bg-gray-700"}`}
       disabled={props.disabled}
       onClick={props.onClick}
       type="button"
     >
-      {props.text !== "" && props.position === "left" && (
-        <div className="mr-2">
+      {props.text && props.text !== "" && props.position === "left" && (
+        <div className="my-auto mr-2">
           {props.text}
         </div>
       )}
       {props.icon && React.cloneElement(props.icon, {
         disabled: props.disabled,
       })}
-      {props.text !== "" && (!props.position || props.position === "right") && (
-        <div className="ml-2">
+      {props.text && props.text !== "" && (!props.position || props.position === "right") && (
+        <div className="my-auto ml-2">
           {props.text}
         </div>
       )}

--- a/components/claim/ClaimActions.tsx
+++ b/components/claim/ClaimActions.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import React from "react";
+
+import * as Separator from "@/components/layout/separator";
+
+import { ClaimButtons } from "@/components/claim/ClaimButtons";
+import { ClaimFooter } from "@/components/claim/ClaimFooter";
+import { ClaimLabels } from "@/components/claim/ClaimLabels";
+import { ClaimStake } from "@/modules/claim/object/ClaimStake";
+
+interface Props {
+  labels: string[];
+  lifecycle: string;
+  stake: ClaimStake;
+  token: string;
+}
+
+export const ClaimActions = (props: Props) => {
+  const [show, setShow] = React.useState<string>("");
+
+  return (
+    // This relative container is the anchor for elements inside of the
+    // ClaimButtons component. When any of the claim buttons is clicked, we
+    // overlay an element to explain some details about staking reputation. And
+    // the overlay does only work properly when this div wrapper here provides
+    // the anchor with its relative position.
+    <div
+      className={`
+        relative w-full py-2
+        border
+        ${show !== "" ? "border-color rounded background-overlay" : "border-background"}
+      `}
+    >
+      <ClaimLabels labels={props.labels} lifecycle={props.lifecycle} />
+
+      <div className="px-2">
+        <Separator.Horizontal />
+      </div>
+
+      <ClaimButtons
+        setShow={setShow}
+        show={show}
+      />
+
+      <ClaimFooter stake={props.stake} token={props.token} />
+    </div>
+  );
+};

--- a/components/claim/ClaimButtons.tsx
+++ b/components/claim/ClaimButtons.tsx
@@ -1,28 +1,85 @@
-import { ClaimObject } from "@/modules/claim/object/ClaimObject";
+import { BaseButton } from "@/components/button/BaseButton";
+import { XMarkIcon } from "@/components/icon/XMarkIcon";
 
 interface Props {
-  claim: ClaimObject;
+  setShow: (show: string) => void;
+  show: string;
 }
 
 export const ClaimButtons = (props: Props) => {
   return (
-    <div className="flex">
-      <div className="w-full mr-2">
-        <button
-          className="p-4 w-full rounded text-gray-800 hover:text-black bg-emerald-400 hover:bg-emerald-500"
-          type="button"
-        >
-          Agree
-        </button>
-      </div>
-      <div className="w-full ml-2">
-        <button
-          className="p-4 w-full rounded text-gray-900 hover:text-black bg-rose-400 hover:bg-rose-500"
-          type="button"
-        >
-          Disagree
-        </button>
-      </div>
-    </div>
+    <>
+      {props.show && (
+        <>
+          <div className="absolute top-0 flex w-full h-14 rounded-t background-overlay">
+            <div className="flex-1 p-2 text-xs">
+              You are staking reputation in <strong> {props.show} </strong> with
+              the proposed claim. Funds cannot be withdrawn, but will be
+              distributed according to this market's resolution.
+            </div>
+
+            <div className="flex-none">
+              <BaseButton
+                hover="hover:text-black enabled:dark:hover:text-white"
+                icon={<XMarkIcon />}
+                onClick={() => props.setShow("")}
+              />
+            </div>
+          </div>
+
+          <div className="flex px-2 h-14">
+            <div className="w-full mr-2">
+              <input
+                className={`
+                  w-full h-full
+                  background-overlay outline-none
+                  placeholder:text-gray-400 placeholder:dark:text-gray-500
+                  text-2xl sm:text-4xl font-light text-right caret-sky-400
+                `}
+                onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
+                  if (e.key === "Escape") props.setShow("");
+                }}
+                placeholder="0.003 ETH"
+                autoFocus={true}
+                type="text"
+              />
+            </div>
+
+            <div className="w-full ml-2">
+              <button
+                className="p-4 w-full rounded text-gray-900 hover:text-black bg-sky-400 hover:bg-sky-500"
+                type="button"
+              >
+                Stake Reputation
+              </button>
+            </div>
+          </div>
+        </>
+      )}
+
+      {!props.show && (
+        <div className="flex px-2">
+          <div className="w-full mr-2">
+            <button
+              className="p-4 w-full rounded text-gray-800 hover:text-black bg-emerald-400 hover:bg-emerald-500"
+              onClick={() => props.setShow("agreement")}
+              type="button"
+            >
+              Agree
+            </button>
+          </div>
+
+          <div className="w-full ml-2">
+            <button
+              className="p-4 w-full rounded text-gray-900 hover:text-black bg-rose-400 hover:bg-rose-500"
+              onClick={() => props.setShow("disagreement")}
+              type="button"
+            >
+              Disagree
+            </button>
+          </div>
+        </div>
+      )}
+    </>
   );
 };

--- a/components/claim/ClaimButtons.tsx
+++ b/components/claim/ClaimButtons.tsx
@@ -15,7 +15,7 @@ export const ClaimButtons = (props: Props) => {
             <div className="flex-1 p-2 text-xs">
               You are staking reputation in <strong> {props.show} </strong> with
               the proposed claim. Funds cannot be withdrawn, but will be
-              distributed according to this market's resolution.
+              distributed according to this market&apos;s resolution.
             </div>
 
             <div className="flex-none">

--- a/components/claim/ClaimContainer.tsx
+++ b/components/claim/ClaimContainer.tsx
@@ -1,10 +1,6 @@
-import * as Separator from "@/components/layout/separator";
-
-import { ClaimButtons } from "@/components/claim/ClaimButtons";
+import { ClaimActions } from "@/components/claim/ClaimActions";
 import { ClaimContent } from "@/components/claim/ClaimContent";
-import { ClaimFooter } from "@/components/claim/ClaimFooter";
 import { ClaimHeader } from "@/components/claim/ClaimHeader";
-import { ClaimLabels } from "@/components/claim/ClaimLabels";
 import { ClaimObject } from "@/modules/claim/object/ClaimObject";
 
 interface Props {
@@ -13,13 +9,18 @@ interface Props {
 
 export const ClaimContainer = (props: Props) => {
   return (
-    <div className="mb-8 p-2 rounded sm:border border-gray-200 dark:border-gray-700">
-      <ClaimHeader claim={props.claim} />
-      <ClaimContent claim={props.claim} />
-      <ClaimLabels claim={props.claim} />
-      <Separator.Horizontal />
-      <ClaimButtons claim={props.claim} />
-      <ClaimFooter claim={props.claim} />
-    </div >
+    <div className="mb-8">
+      <div className="p-2 w-full">
+        <ClaimHeader claim={props.claim} />
+        <ClaimContent claim={props.claim} />
+      </div>
+
+      <ClaimActions
+        labels={props.claim.labels()}
+        lifecycle={props.claim.lifecycle()}
+        stake={props.claim.stake()}
+        token={props.claim.token()}
+      />
+    </div>
   );
 };

--- a/components/claim/ClaimFooter.tsx
+++ b/components/claim/ClaimFooter.tsx
@@ -1,29 +1,30 @@
 import { BaseButton } from "@/components/button/BaseButton";
-import { ClaimObject } from "@/modules/claim/object/ClaimObject";
+import { ClaimStake } from "@/modules/claim/object/ClaimStake";
 import { TriangleDownIcon } from "@/components/icon/TriangleDownIcon";
 import { TriangleUpIcon } from "@/components/icon/TriangleUpIcon";
 
 interface Props {
-  claim: ClaimObject;
+  stake: ClaimStake;
+  token: string;
 }
 
 export const ClaimFooter = (props: Props) => {
   return (
-    <div className="flex mt-2 text-gray-500 dark:text-gray-400">
+    <div className="flex mt-2 px-2 text-gray-500 dark:text-gray-400">
       <div className="flex-1 relative">
         <div className="absolute left-0 w-fit">
           <BaseButton
             font="font-normal"
-            icon={<TriangleUpIcon className="mb-[2px]" />}
+            icon={<TriangleUpIcon className="mb-[1px]" />}
             position="right"
-            text={`${props.claim.stake().agree.toFixed(2)} ${props.claim.token()}`}
+            text={`${props.stake.agree.toFixed(2)} ${props.token}`}
           />
         </div>
       </div>
 
       <div className="flex-1 w-full">
         <div className="mx-auto p-2 w-fit text-gray-400 dark:text-gray-500 underline underline-offset-4 decoration-dashed cursor-default">
-          {`${props.claim.stake().pnl.toFixed(2)} %`}
+          {`${props.stake.pnl.toFixed(2)} %`}
         </div>
       </div>
 
@@ -31,9 +32,9 @@ export const ClaimFooter = (props: Props) => {
         <div className="absolute right-0 w-fit">
           <BaseButton
             font="font-normal"
-            icon={<TriangleDownIcon className="mb-[2px]" />}
+            icon={<TriangleDownIcon className="mb-[1px]" />}
             position="left"
-            text={`${props.claim.stake().disagree.toFixed(2)} ${props.claim.token()}`}
+            text={`${props.stake.disagree.toFixed(2)} ${props.token}`}
           />
         </div>
       </div>

--- a/components/claim/ClaimHeader.tsx
+++ b/components/claim/ClaimHeader.tsx
@@ -9,7 +9,7 @@ interface Props {
 export const ClaimHeader = (props: Props) => {
   return (
     <div className="flex">
-      <div className="flex-none w-12 h-12 mr-2 rounded bg-gray-100 dark:bg-gray-800 border border-color">
+      <div className="flex-none w-12 h-12 mr-2 rounded background-overlay border border-color">
         {props.claim.owner().image()}
       </div>
       <div className="flex-1 w-full">

--- a/components/claim/ClaimLabels.tsx
+++ b/components/claim/ClaimLabels.tsx
@@ -1,16 +1,16 @@
-import { ClaimObject } from "@/modules/claim/object/ClaimObject";
 import { LabelList } from "@/components/claim/LabelList";
 
 interface Props {
-  claim: ClaimObject;
+  labels: string[];
+  lifecycle: string;
 }
 
 export const ClaimLabels = (props: Props) => {
   return (
-    <div className="">
+    <div className="px-2">
       <LabelList
-        labels={props.claim.labels()}
-        lifecycle={props.claim.lifecycle()}
+        labels={props.labels}
+        lifecycle={props.lifecycle}
       />
     </div>
   );

--- a/components/layout/separator.tsx
+++ b/components/layout/separator.tsx
@@ -3,9 +3,19 @@ import * as Separator from "@radix-ui/react-separator";
 export const Horizontal = () => {
   return (
     <Separator.Root
-      className="my-4 border-b-[1px] border-color data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px"
+      className="my-4 border-t-[1px] border-color data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px"
       decorative
       orientation="horizontal"
+    />
+  );
+};
+
+export const Vertical = () => {
+  return (
+    <Separator.Root
+      className="mx-auto border-r-[1px] border-color border-dashed data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px"
+      decorative
+      orientation="vertical"
     />
   );
 };

--- a/components/sidebar/Sidebar.tsx
+++ b/components/sidebar/Sidebar.tsx
@@ -45,7 +45,7 @@ export const Sidebar = () => {
   return (
     <div
       className={`
-        fixed top-0 left-0 w-64 flex flex-row h-screen transition-transform transform
+        fixed top-0 left-0 z-10 w-64 flex flex-row h-screen transition-transform transform
         background
         ${show ? 'translate-x-0' : '-translate-x-full'}
       `}

--- a/modules/claim/object/ClaimObject.ts
+++ b/modules/claim/object/ClaimObject.ts
@@ -1,17 +1,9 @@
 import moment from "moment";
 
+import { ClaimStake } from "@/modules/claim/object/ClaimStake";
 import { PostSearchResponse } from "@/modules/api/post/search/Response";
 import { SplitList } from "@/modules/string/SplitList";
 import { UserObject } from "@/modules/user/object/UserObject";
-
-interface ClaimStake {
-  agree: number;
-  disagree: number;
-  initial: number;
-  minimum: number;
-  pnl: number;
-  user: number;
-}
 
 export class ClaimObject {
   private claimStake: ClaimStake;

--- a/modules/claim/object/ClaimStake.ts
+++ b/modules/claim/object/ClaimStake.ts
@@ -1,0 +1,8 @@
+export interface ClaimStake {
+  agree: number;
+  disagree: number;
+  initial: number;
+  minimum: number;
+  pnl: number;
+  user: number;
+}


### PR DESCRIPTION
The goal here is to maintain our claim layout as defined by out mockups. There has to be some interface change when clicking the buttons to either agree or disagree with the proposed claim. Clicking either of those buttons, the user has to provide some amount of reputation, so that those tokens can be staked in an onchain transaction. The challenge here was to integrate the transaction modal seamlessly into our existing design.

The screenshots below show the claim buttons before the user clicks any of them, and the modal after clicking either of those green and red buttons. The inline modal explains the action and shows an input field for the user. Note that the design changes here include the removal of the claim container border, which makes the modal implementation simpler, and the design leaner overall. A vertical separator has been added to differentiate between a list of claims, since the removed border of the claim container makes it more difficult to distinguish claims when scrolling up and down.

The input field in the staking modal has an auto focus so that the user can directly type an amount. As long as the input field has focus, the user can press ESC and remove the modal as if pressing the X mark button to return to the previous view.

Note that no form or transaction handling is implemented here. This PR is only for the modal UX. If you would like to try out the change yourself you only need to execute `npm run dev` and go to http://localhost:3000/claim/tree/123.

<img width="644" alt="Screenshot 2024-07-30 at 16 04 45" src="https://github.com/user-attachments/assets/fd7b5bff-bbab-405f-b314-f0d9c4c0ef22">

---

<img width="644" alt="Screenshot 2024-07-30 at 16 04 49" src="https://github.com/user-attachments/assets/62b54fed-1897-4058-ad09-3a2e20e4683d">

---

<img width="644" alt="Screenshot 2024-07-30 at 16 04 54" src="https://github.com/user-attachments/assets/f9b8307d-760f-4d33-8b16-70c853a9b618">

---

<img width="644" alt="Screenshot 2024-07-30 at 16 05 02" src="https://github.com/user-attachments/assets/2e17c431-ded1-4e16-804a-0a376e71be02">