### PR TITLE
add hover card for detailed claim performance info

### DIFF
--- a/app/claim/tree/[slug]/page.tsx
+++ b/app/claim/tree/[slug]/page.tsx
@@ -31,7 +31,7 @@ const list: ClaimObject[] = [
     kind: "claim",
     labels: "econ, finance",
     lifecycle: "propose",
-    option: "true",
+    option: "",
     stake: "15.273,2.773,0.5,0.5,1.5",
     parent: "",
     text: markdown,
@@ -49,8 +49,8 @@ const list: ClaimObject[] = [
     kind: "claim",
     labels: "crypto, foobar",
     lifecycle: "resolve",
-    option: "false",
-    stake: "15.273,2.773,0.5,0.5,1.5",
+    option: "true",
+    stake: "2.773,15.273,0.5,0.5,1.5",
     parent: "1",
     text: markdown,
     token: "ETH",
@@ -65,8 +65,8 @@ export default function Page({ params }: { params: { slug: string } }) {
       <PageHeader titl="Claim Tree" />
 
       {list.map((x: ClaimObject, i: number) => (
-        <>
-          <ClaimContainer key={x.id()} claim={x} />
+        <div key={x.id()}>
+          <ClaimContainer claim={x} />
 
           {/*
           Show a vertical separator between claims and make sure that the last
@@ -77,7 +77,7 @@ export default function Page({ params }: { params: { slug: string } }) {
               <Separator.Vertical />
             </div>
           )}
-        </>
+        </div>
       ))}
     </>
   );

--- a/components/claim/ClaimActions.tsx
+++ b/components/claim/ClaimActions.tsx
@@ -7,17 +7,19 @@ import * as Separator from "@/components/layout/separator";
 import { ClaimButtons } from "@/components/claim/ClaimButtons";
 import { ClaimFooter } from "@/components/claim/ClaimFooter";
 import { ClaimLabels } from "@/components/claim/ClaimLabels";
+import { ClaimOption } from "@/modules/claim/object/ClaimOption";
 import { ClaimStake } from "@/modules/claim/object/ClaimStake";
 
 interface Props {
   labels: string[];
   lifecycle: string;
+  option: ClaimOption;
   stake: ClaimStake;
   token: string;
 }
 
 export const ClaimActions = (props: Props) => {
-  const [show, setShow] = React.useState<string>("");
+  const [open, setOpen] = React.useState<string>("");
 
   return (
     // This relative container is the anchor for elements inside of the
@@ -29,21 +31,28 @@ export const ClaimActions = (props: Props) => {
       className={`
         relative w-full py-2
         border
-        ${show !== "" ? "border-color rounded background-overlay" : "border-background"}
+        ${open !== "" ? "background-overlay border-color rounded" : "border-background"}
       `}
     >
-      <ClaimLabels labels={props.labels} lifecycle={props.lifecycle} />
+      <ClaimLabels
+        labels={props.labels}
+        lifecycle={props.lifecycle}
+      />
 
       <div className="px-2">
         <Separator.Horizontal />
       </div>
 
       <ClaimButtons
-        setShow={setShow}
-        show={show}
+        setOpen={setOpen}
+        open={open}
       />
 
-      <ClaimFooter stake={props.stake} token={props.token} />
+      <ClaimFooter
+        option={props.option}
+        stake={props.stake}
+        token={props.token}
+      />
     </div>
   );
 };

--- a/components/claim/ClaimButtons.tsx
+++ b/components/claim/ClaimButtons.tsx
@@ -2,18 +2,18 @@ import { BaseButton } from "@/components/button/BaseButton";
 import { XMarkIcon } from "@/components/icon/XMarkIcon";
 
 interface Props {
-  setShow: (show: string) => void;
-  show: string;
+  setOpen: (open: string) => void;
+  open: string;
 }
 
 export const ClaimButtons = (props: Props) => {
   return (
     <>
-      {props.show && (
+      {props.open && (
         <>
           <div className="absolute top-0 flex w-full h-14 rounded-t background-overlay">
             <div className="flex-1 p-2 text-xs">
-              You are staking reputation in <strong> {props.show} </strong> with
+              You are staking reputation in <strong> {props.open} </strong> with
               the proposed claim. Funds cannot be withdrawn, but will be
               distributed according to this market&apos;s resolution.
             </div>
@@ -22,7 +22,7 @@ export const ClaimButtons = (props: Props) => {
               <BaseButton
                 hover="hover:text-black enabled:dark:hover:text-white"
                 icon={<XMarkIcon />}
-                onClick={() => props.setShow("")}
+                onClick={() => props.setOpen("")}
               />
             </div>
           </div>
@@ -37,7 +37,7 @@ export const ClaimButtons = (props: Props) => {
                   text-2xl sm:text-4xl font-light text-right caret-sky-400
                 `}
                 onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
-                  if (e.key === "Escape") props.setShow("");
+                  if (e.key === "Escape") props.setOpen("");
                 }}
                 placeholder="0.003 ETH"
                 autoFocus={true}
@@ -57,12 +57,12 @@ export const ClaimButtons = (props: Props) => {
         </>
       )}
 
-      {!props.show && (
+      {!props.open && (
         <div className="flex px-2">
           <div className="w-full mr-2">
             <button
               className="p-4 w-full rounded text-gray-800 hover:text-black bg-emerald-400 hover:bg-emerald-500"
-              onClick={() => props.setShow("agreement")}
+              onClick={() => props.setOpen("agreement")}
               type="button"
             >
               Agree
@@ -72,7 +72,7 @@ export const ClaimButtons = (props: Props) => {
           <div className="w-full ml-2">
             <button
               className="p-4 w-full rounded text-gray-900 hover:text-black bg-rose-400 hover:bg-rose-500"
-              onClick={() => props.setShow("disagreement")}
+              onClick={() => props.setOpen("disagreement")}
               type="button"
             >
               Disagree

--- a/components/claim/ClaimContainer.tsx
+++ b/components/claim/ClaimContainer.tsx
@@ -18,6 +18,7 @@ export const ClaimContainer = (props: Props) => {
       <ClaimActions
         labels={props.claim.labels()}
         lifecycle={props.claim.lifecycle()}
+        option={props.claim.option()}
         stake={props.claim.stake()}
         token={props.claim.token()}
       />

--- a/components/claim/ClaimFooter.tsx
+++ b/components/claim/ClaimFooter.tsx
@@ -1,16 +1,19 @@
 import { BaseButton } from "@/components/button/BaseButton";
+import { ClaimFooterCard } from "@/components/claim/ClaimFooterCard";
+import { ClaimOption } from "@/modules/claim/object/ClaimOption";
 import { ClaimStake } from "@/modules/claim/object/ClaimStake";
 import { TriangleDownIcon } from "@/components/icon/TriangleDownIcon";
 import { TriangleUpIcon } from "@/components/icon/TriangleUpIcon";
 
 interface Props {
+  option: ClaimOption;
   stake: ClaimStake;
   token: string;
 }
 
 export const ClaimFooter = (props: Props) => {
   return (
-    <div className="flex mt-2 px-2 text-gray-500 dark:text-gray-400">
+    <div className="flex mt-2 px-2">
       <div className="flex-1 relative">
         <div className="absolute left-0 w-fit">
           <BaseButton
@@ -23,8 +26,12 @@ export const ClaimFooter = (props: Props) => {
       </div>
 
       <div className="flex-1 w-full">
-        <div className="mx-auto p-2 w-fit text-gray-400 dark:text-gray-500 underline underline-offset-4 decoration-dashed cursor-default">
-          {`${props.stake.pnl.toFixed(2)} %`}
+        <div className="mx-auto w-fit">
+          <ClaimFooterCard
+            option={props.option}
+            stake={props.stake}
+            token={props.token}
+          />
         </div>
       </div>
 

--- a/components/claim/ClaimFooterCard.tsx
+++ b/components/claim/ClaimFooterCard.tsx
@@ -1,0 +1,69 @@
+import * as HoverCard from "@radix-ui/react-hover-card";
+
+import { ClaimOption } from "@/modules/claim/object/ClaimOption";
+import { ClaimStake } from "@/modules/claim/object/ClaimStake";
+
+interface Props {
+  option: ClaimOption;
+  stake: ClaimStake;
+  token: string;
+}
+
+export const ClaimFooterCard = (props: Props) => {
+  const agreement = props.option.agree ? "agreement" : "disagreement";
+  const probability = props.stake.probability.toFixed(0);
+  const upside = props.stake.upside.toFixed(0);
+
+  return (
+    <HoverCard.Root
+      closeDelay={500}
+      openDelay={250}
+    >
+      <HoverCard.Trigger asChild>
+        <div className="p-2 text-gray-400 dark:text-gray-500 underline underline-offset-4 decoration-dashed cursor-default">
+          {`${probability} %`}
+        </div>
+      </HoverCard.Trigger>
+      <HoverCard.Portal>
+        <HoverCard.Content
+          className={`
+            p-2 w-[300px]
+            background border-color border rounded
+            data-[state=open]:transition-all
+            data-[side=bottom]:animate-slideUpAndFade
+            data-[side=right]:animate-slideLeftAndFade
+            data-[side=left]:animate-slideRightAndFade
+            data-[side=top]:animate-slideDownAndFade
+          `}
+          side="top"
+          sideOffset={5}
+        >
+          <div className="text-gray-500 dark:text-gray-400 text-sm">
+            This claim has a probability of <strong>{probability}%</strong> to
+            be true.
+
+            <br /><br />
+
+            {props.option.stake && (
+              <div>
+                You have {props.stake.user} {props.token} staked in&nbsp;
+                <strong>{agreement}</strong> with the proposed claim.
+
+                <br /><br />
+
+                Your potential upside is currently <strong>{upside}%</strong>,
+                for which this market must be resolved in your favour.
+              </div>
+            )}
+
+            {!props.option.stake && (
+              <div>
+                You have no reputation staked in this market.
+              </div>
+            )}
+          </div>
+        </HoverCard.Content>
+      </HoverCard.Portal>
+    </HoverCard.Root>
+  );
+};

--- a/modules/claim/object/ClaimOption.ts
+++ b/modules/claim/object/ClaimOption.ts
@@ -1,0 +1,11 @@
+export interface ClaimOption {
+  agree: boolean;
+  stake: boolean;
+}
+
+export const ParseClaimOption = (opt: string): ClaimOption => {
+  return {
+    agree: opt.toLowerCase() === "true",
+    stake: opt.toLowerCase() !== "",
+  };
+};

--- a/modules/claim/object/ClaimStake.ts
+++ b/modules/claim/object/ClaimStake.ts
@@ -1,8 +1,81 @@
+import { ClaimOption } from "@/modules/claim/object/ClaimOption";
+import { SplitList } from "@/modules/string/SplitList";
+
 export interface ClaimStake {
   agree: number;
   disagree: number;
   initial: number;
   minimum: number;
-  pnl: number;
+  probability: number;
+  upside: number;
   user: number;
 }
+
+// CalculateClaimStake takes the apischema formatted string of staking
+// information for the given claim and returns an object of relevant staking
+// information in structured form. The inline comments below are based on the
+// following apischema formatted string value, where, as a reminder, the format
+// is "agreement,disagree,minimum,initial,user".
+//
+//     "15.273,2.773,0.5,0.5,1.5"
+//
+export const CalculateClaimStake = (stk: string, opt: ClaimOption): ClaimStake => {
+  const num = SplitList(stk).map((x: string) => {
+    return parseFloat(x);
+  });
+
+  let claimStake: ClaimStake = {
+    agree: num[0],
+    disagree: num[1],
+    initial: num[3],
+    minimum: num[2],
+    probability: 0,
+    upside: 0,
+    user: num[4],
+  };
+
+  // Calculate the probability as the fraction of staked reputation that agrees
+  // with the proposed claim. If for instance 9 ETH are staked in agreement and
+  // 1 ETH is staked in disagreement, then the claims probability is 90%. On the
+  // other hand, if there would be only 1 ETH staked in agreement, and 9 ETH
+  // staked in disagreement, the proposed claim would only have a probability of
+  // 10% to be true.
+  {
+    claimStake.probability = claimStake.agree / (claimStake.agree + claimStake.disagree) * 100;
+  }
+
+  // Only calculate the callers upside if that very user did in fact participate
+  // in the given market. If the provided apischema option is neither "true" nor
+  // "false", but an empty string, then this means that the caller has no skin
+  // in the game here.
+  if (opt.stake) {
+    claimStake.upside = calculateUpside(claimStake, opt);
+  }
+
+  return claimStake;
+};
+
+const calculateUpside = (stk: ClaimStake, opt: ClaimOption): number => {
+  // Calculate the user's share of stake according to the option that the user
+  // expressed their opinion on.
+  //
+  //     1.5 / 15.273 = 0.09821253192
+  //
+  const share = stk.user / (opt.stake && opt.agree ? stk.agree : stk.disagree);
+
+  // Calculate the user's token rewards according to the other side of the bet
+  // that the user can capture.
+  //
+  //     0.09821253192 * 2.773 = 0.272343351
+  //
+  const reward = share * (opt.stake && opt.agree ? stk.disagree : stk.agree);
+
+  // Calculate the user's potential upside based on hypothetical rewards, as if
+  // the user would be proven right upon claim resolution.
+  //
+  //     0.272343351 / 1.5 = 0.181562234
+  //
+  const upside = reward / stk.user * 100;
+
+  return upside;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@privy-io/react-auth": "^1.76.2",
         "@radix-ui/react-dropdown-menu": "^2.1.1",
+        "@radix-ui/react-hover-card": "^1.1.1",
         "@radix-ui/react-separator": "^1.1.0",
         "@radix-ui/react-toast": "^1.2.1",
         "@uvio-network/apitscode": "github:uvio-network/apitscode#v0.1.0",
@@ -2507,6 +2508,36 @@
         "@radix-ui/react-compose-refs": "1.1.0",
         "@radix-ui/react-primitive": "2.0.0",
         "@radix-ui/react-use-callback-ref": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-hover-card": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-hover-card/-/react-hover-card-1.1.1.tgz",
+      "integrity": "sha512-IwzAOP97hQpDADYVKrEEHUH/b2LA+9MgB0LgdmnbFO2u/3M5hmEofjjr2M6CyzUblaAqJdFm6B7oFtU72DPXrA==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-dismissable-layer": "1.1.0",
+        "@radix-ui/react-popper": "1.2.0",
+        "@radix-ui/react-portal": "1.1.1",
+        "@radix-ui/react-presence": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@privy-io/react-auth": "^1.76.2",
     "@radix-ui/react-dropdown-menu": "^2.1.1",
+    "@radix-ui/react-hover-card": "^1.1.1",
     "@radix-ui/react-separator": "^1.1.0",
     "@radix-ui/react-toast": "^1.2.1",
     "@uvio-network/apitscode": "github:uvio-network/apitscode#v0.1.0",


### PR DESCRIPTION
Hovering over the underlined percentage in the middle shows more detailed information about the given claim performance. At a glance users can now see the probability of a claim being true, and understand better what kind of upside they may or may not have. Users are also informed about the fact whether they have participated in the given claim or not.

<img width="644" alt="Screenshot 2024-07-30 at 19 23 56" src="https://github.com/user-attachments/assets/57e6da20-65f7-4a0f-acf6-db3ddb20438d">

---

<img width="644" alt="Screenshot 2024-07-30 at 19 24 38" src="https://github.com/user-attachments/assets/e7dc3b7a-4c1b-46f0-bd5f-6cec65ef7929">
