### PR TITLE
fix background colour and minimum stake

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -11,10 +11,12 @@
 /* font */
 
 .dark {
+  background-color: black;
   color: white;
 }
 
 .light {
+  background-color: white;
   color: black;
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,16 +13,16 @@ export const metadata: Metadata = {
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
+    <html className="min-h-screen" lang="en">
       {/*
       Note that the body element will receive either the "light" or "dark" class
       based on the chosen theme.
       */}
-      <body className={inter.className}>
+      <body className={`min-h-screen ${inter.className}`}>
 
         <AppProvider>
 
-          <div className="py-4 px-2 background justify-items-center">
+          <div className="py-4 px-2  background justify-items-center">
             <div className="m-auto w-full max-w-xl">
               {/*
               The div below works together with the Sidebar component to ensure

--- a/components/claim/ClaimActions.tsx
+++ b/components/claim/ClaimActions.tsx
@@ -44,8 +44,10 @@ export const ClaimActions = (props: Props) => {
       </div>
 
       <ClaimButtons
-        setOpen={setOpen}
         open={open}
+        setOpen={setOpen}
+        stake={props.stake}
+        token={props.token}
       />
 
       <ClaimFooter

--- a/components/claim/ClaimButtons.tsx
+++ b/components/claim/ClaimButtons.tsx
@@ -1,9 +1,12 @@
 import { BaseButton } from "@/components/button/BaseButton";
+import { ClaimStake } from "@/modules/claim/object/ClaimStake";
 import { XMarkIcon } from "@/components/icon/XMarkIcon";
 
 interface Props {
-  setOpen: (open: string) => void;
   open: string;
+  setOpen: (open: string) => void;
+  stake: ClaimStake;
+  token: string;
 }
 
 export const ClaimButtons = (props: Props) => {
@@ -39,7 +42,7 @@ export const ClaimButtons = (props: Props) => {
                 onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
                   if (e.key === "Escape") props.setOpen("");
                 }}
-                placeholder="0.003 ETH"
+                placeholder={`${props.stake.minimum} ${props.token}`}
                 autoFocus={true}
                 type="text"
               />
@@ -49,6 +52,7 @@ export const ClaimButtons = (props: Props) => {
               <button
                 className="p-4 w-full rounded text-gray-900 hover:text-black bg-sky-400 hover:bg-sky-500"
                 type="button"
+              // TODO process submit, validate input, handle errors like minimum stake too low
               >
                 Stake Reputation
               </button>

--- a/components/sidebar/button/ThemeButton.tsx
+++ b/components/sidebar/button/ThemeButton.tsx
@@ -151,16 +151,18 @@ const getThm = (): string => {
   return thmSys;
 };
 
-// setDrk adds the "dark" classname to the dom's body and removes the classname
-// "light". That classname change enables Tailwind to switch the colour theme.
+// setDrk adds the "dark" classname to the dom's document element and removes
+// the classname "light". That classname change enables Tailwind to switch the
+// colour theme.
 const setDrk = () => {
-  document.body.classList.add(thmDrk);
-  document.body.classList.remove(thmLgt);
+  document.documentElement.classList.add(thmDrk);
+  document.documentElement.classList.remove(thmLgt);
 };
 
-// setLgt adds the "light" classname to the dom's body and removes the classname
-// "dark". That classname change enables Tailwind to switch the colour theme.
+// setLgt adds the "light" classname to the dom's document element and removes
+// the classname "dark". That classname change enables Tailwind to switch the
+// colour theme.
 const setLgt = () => {
-  document.body.classList.add(thmLgt);
-  document.body.classList.remove(thmDrk);
+  document.documentElement.classList.add(thmLgt);
+  document.documentElement.classList.remove(thmDrk);
 };


### PR DESCRIPTION
I am lazy here now and do two different things at once.

1. By accident I noticed that the theme class names were not attached to the html document itself, but lower down the stack. That caused glitches when scrolling at the upper and lower edges of the screen. We fix this here by placing the theme class names properly and adjusting the CSS properties accordingly.

2. We set the input placeholder in the stake transaction modal to the minimum stake. The hint here should help choosing the right amount of reputation to stake.