### PR TITLE
manage claim labels and render claim page on creation

### DIFF
--- a/app/claim/[slug]/page.tsx
+++ b/app/claim/[slug]/page.tsx
@@ -24,7 +24,7 @@ export default function Page({ params }: { params: { slug: string } }) {
     {
       fetchData();
     }
-  }, []);
+  }, [params.slug]);
 
   return (
     <>

--- a/app/claim/[slug]/page.tsx
+++ b/app/claim/[slug]/page.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import React from "react";
+
+import { AuthStore } from "@/components/auth/AuthStore";
+import { ClaimContainer } from "@/components/claim/ClaimContainer";
+import { ClaimObject } from "@/modules/claim/object/ClaimObject";
+import { PageHeader } from "@/components/page/PageHeader";
+import { PostSearch } from "@/modules/api/post/search/Search";
+import { UserSearch } from "@/modules/api/user/search/Search";
+
+export default function Page({ params }: { params: { slug: string } }) {
+  const [claim, setClaim] = React.useState<ClaimObject | null>(null);
+
+  // TODO make sure the calls below are only made once per page load
+  React.useEffect(() => {
+    const fetchData = async () => {
+      const [pos] = await PostSearch(AuthStore.getState().auth.token, [{ id: params.slug }]);
+      const [use] = await UserSearch(AuthStore.getState().auth.token, [{ id: pos.owner }]);
+
+      setClaim(new ClaimObject(pos, use));
+    };
+
+    {
+      fetchData();
+    }
+  }, []);
+
+  return (
+    <>
+      <PageHeader titl="Claim Object" />
+
+      {claim && (
+        <ClaimContainer claim={claim} />
+      )}
+    </>
+  );
+};

--- a/app/claim/tree/[slug]/page.tsx
+++ b/app/claim/tree/[slug]/page.tsx
@@ -19,45 +19,61 @@ electronic typesetting, remaining essentially unchanged.
 `;
 
 const list: ClaimObject[] = [
-  new ClaimObject({
-    // intern
-    created: "1722254829",
-    id: "1",
-    owner: "",
-    tree: "123",
+  new ClaimObject(
+    {
+      // intern
+      created: "1722254829",
+      id: "1",
+      owner: "",
+      tree: "123",
 
-    // public
-    expiry: "1763766000",
-    kind: "claim",
-    labels: "econ, finance",
-    lifecycle: "propose",
-    option: "",
-    stake: "15.273,2.773,0.5,0.5,1.5",
-    parent: "",
-    text: markdown,
-    token: "ETH",
-  }),
-  new ClaimObject({
-    // intern
-    created: "1722254829",
-    id: "2",
-    owner: "",
-    tree: "123",
+      // public
+      expiry: "1763766000",
+      kind: "claim",
+      labels: "econ, finance",
+      lifecycle: "propose",
+      option: "",
+      stake: "15.273,2.773,0.5,0.5,1.5",
+      parent: "",
+      text: markdown,
+      token: "ETH",
+    },
+    {
+      created: "",
+      id: "8236427635",
+      image: "",
+      name: "RevengeArch47",
+    },
+  ),
+  new ClaimObject(
+    {
+      // intern
+      created: "1722254829",
+      id: "2",
+      owner: "",
+      tree: "123",
 
-    // public
-    expiry: "1763766000",
-    kind: "claim",
-    labels: "crypto, foobar",
-    lifecycle: "resolve",
-    option: "true",
-    stake: "2.773,15.273,0.5,0.5,1.5",
-    parent: "1",
-    text: markdown,
-    token: "ETH",
-  }),
+      // public
+      expiry: "1763766000",
+      kind: "claim",
+      labels: "crypto, foobar",
+      lifecycle: "resolve",
+      option: "true",
+      stake: "2.773,15.273,0.5,0.5,1.5",
+      parent: "1",
+      text: markdown,
+      token: "ETH",
+    },
+    {
+      created: "",
+      id: "8236427635",
+      image: "",
+      name: "RevengeArch47",
+    },
+  ),
 ];
 
-export default function Page({ props }: { props: { slug: string } }) {
+export default function Page({ params }: { params: { slug: string } }) {
   // TODO fetch claim tree
   // TODO fetch all relevant users
   return (

--- a/app/claim/tree/[slug]/page.tsx
+++ b/app/claim/tree/[slug]/page.tsx
@@ -57,7 +57,7 @@ const list: ClaimObject[] = [
   }),
 ];
 
-export default function Page({ params }: { params: { slug: string } }) {
+export default function Page({ props }: { props: { slug: string } }) {
   // TODO fetch claim tree
   // TODO fetch all relevant users
   return (

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -22,7 +22,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
 
         <AppProvider>
 
-          <div className="py-4 px-2  background justify-items-center">
+          <div className="py-4 px-2 background justify-items-center">
             <div className="m-auto w-full max-w-xl">
               {/*
               The div below works together with the Sidebar component to ensure

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,22 +1,11 @@
 "use client";
 
-import { AuthStore } from "@/components/auth/AuthStore";
 import { PageHeader } from "@/components/page/PageHeader";
 
 export default function Page() {
-  const { auth } = AuthStore();
-
   return (
     <>
       <PageHeader titl="Latest Claims" />
-
-      <div>
-        {auth.valid ? (
-          <p>Access Token: {auth.token}</p>
-        ) : (
-          <p>User is not authenticated</p>
-        )}
-      </div>
     </>
   );
 };

--- a/components/app/claim/propose/editor/SubmitButton.tsx
+++ b/components/app/claim/propose/editor/SubmitButton.tsx
@@ -1,10 +1,15 @@
 import { SubmitForm } from "@/modules/app/claim/propose/form/SubmitForm";
+import { useRouter } from "next/navigation";
 
 export const SubmitButton = () => {
+  const router = useRouter();
+
   return (
     <button
       className="flex-none px-1 bg-blue-500 text-white rounded"
-      onClick={SubmitForm}
+      onClick={() => {
+        SubmitForm((id: string) => router.push(`/claim/${id}`));
+      }}
       type="button"
     >
       Propose Claim

--- a/components/auth/AuthStore.tsx
+++ b/components/auth/AuthStore.tsx
@@ -2,17 +2,60 @@ import { create } from "zustand";
 import { combine } from "zustand/middleware";
 
 export interface AuthMessage {
+  image: string;
+  name: string;
   token: string;
   valid: boolean;
   wallet: string;
 };
 
+// TODO rename to UserStore
 export const AuthStore = create(
   combine(
     {
       auth: {} as AuthMessage,
     },
     (set) => ({
+      delete: () => {
+        set(() => {
+          return {
+            auth: {
+              image: "",
+              name: "",
+              token: "",
+              valid: false,
+              wallet: "",
+            },
+          };
+        });
+      },
+      update: (a: AuthMessage) => {
+        set(() => {
+          return {
+            auth: a,
+          };
+        });
+      },
+      updateImage: (i: string) => {
+        set((state: { auth: AuthMessage }) => {
+          return {
+            auth: {
+              ...state.auth,
+              image: i,
+            }
+          };
+        });
+      },
+      updateName: (n: string) => {
+        set((state: { auth: AuthMessage }) => {
+          return {
+            auth: {
+              ...state.auth,
+              name: n,
+            }
+          };
+        });
+      },
       updateToken: (t: string) => {
         set((state: { auth: AuthMessage }) => {
           return {

--- a/components/sidebar/button/ProposeButton.tsx
+++ b/components/sidebar/button/ProposeButton.tsx
@@ -6,14 +6,15 @@ import { AuthStore } from "@/components/auth/AuthStore";
 import { BaseButton } from "@/components/button/BaseButton";
 import { AddSquareIcon } from "@/components/icon/AddSquareIcon";
 import { useRouter } from "next/navigation";
+import { useShallow } from "zustand/react/shallow";
 
 export const ProposeButton = () => {
-  const { auth } = AuthStore();
+  const { valid } = AuthStore(useShallow((state) => ({ valid: state.auth.valid })));
 
   const router = useRouter();
 
   const onClick = () => {
-    if (auth.valid) {
+    if (valid) {
       router.push("/claim/propose");
     } else {
       ToastSender.Info("You need to login to propose a claim!");

--- a/components/sidebar/button/UserButton.tsx
+++ b/components/sidebar/button/UserButton.tsx
@@ -5,23 +5,23 @@ import * as ToastSender from "@/components/toast/ToastSender";
 import { AuthStore } from "@/components/auth/AuthStore";
 import { BaseButton } from "@/components/button/BaseButton";
 import { UserFullIcon } from "@/components/icon/UserFullIcon";
-import { truncateEthAddress } from "@/modules/wallet/WalletAddress";
+import { useShallow } from "zustand/react/shallow";
 
 export const UserButton = () => {
-  const { auth } = AuthStore();
+  const { name } = AuthStore(useShallow((state) => ({ name: state.auth.name })));
 
   const onClick = () => {
     ToastSender.Info("It's comming just chill ok!");
   };
 
   let text = "User Profile";
-  if (auth.wallet !== "") {
-    text = truncateEthAddress(auth.wallet);
+  if (name !== "") {
+    text = name;
   }
 
   return (
     <>
-      {auth.valid && (
+      {text && (
         <Link href="">
           <BaseButton
             icon={<UserFullIcon />}

--- a/modules/api/post/create/Create.ts
+++ b/modules/api/post/create/Create.ts
@@ -11,6 +11,7 @@ export async function PostCreate(tok: string, req: PostCreateRequest[]): Promise
           public: {
             expiry: x.expiry,
             kind: x.kind,
+            labels: x.labels,
             lifecycle: x.lifecycle,
             option: x.option,
             parent: x.parent,

--- a/modules/api/post/create/Request.ts
+++ b/modules/api/post/create/Request.ts
@@ -2,6 +2,7 @@ export interface PostCreateRequest {
   // public
   expiry: string;
   kind: string;
+  labels: string;
   lifecycle: string;
   option: string;
   parent: string;

--- a/modules/api/post/search/Request.ts
+++ b/modules/api/post/search/Request.ts
@@ -1,0 +1,13 @@
+export interface PostSearchRequest {
+  // intern
+  id?: string;
+  owner?: string;
+  tree?: string;
+
+  // public
+  labels?: string;
+
+  // symbol
+  list?: string;
+  time?: string;
+}

--- a/modules/api/post/search/Search.ts
+++ b/modules/api/post/search/Search.ts
@@ -1,0 +1,50 @@
+import { API } from "@/modules/api/post/API";
+import { PostSearchRequest } from "@/modules/api/post/search/Request";
+import { PostSearchResponse } from "@/modules/api/post/search/Response";
+
+export async function PostSearch(tok: string, req: PostSearchRequest[]): Promise<PostSearchResponse[]> {
+  try {
+    const cal = await API.search(
+      {
+        object: req.map((x) => ({
+          intern: {
+            id: x.id || "",
+            owner: x.owner || "",
+            tree: x.tree || "",
+          },
+          public: {
+            labels: x.labels || "",
+          },
+          symbol: {
+            list: x.list || "",
+            time: x.time || "",
+          },
+        })),
+      },
+      {
+        meta: tok ? { authorization: "Bearer " + tok } : {},
+      },
+    );
+
+    return cal.response.object.map((x) => ({
+      // intern
+      created: x.intern?.created || "",
+      id: x.intern?.id || "",
+      owner: x.intern?.owner || "",
+      tree: x.intern?.tree || "",
+
+      //public
+      expiry: x.public?.expiry || "",
+      kind: x.public?.kind || "",
+      labels: x.public?.labels || "",
+      lifecycle: x.public?.lifecycle || "",
+      option: x.public?.option || "",
+      stake: x.public?.stake || "",
+      parent: x.public?.parent || "",
+      text: x.public?.text || "",
+      token: x.public?.token || "",
+    }));
+  } catch (err) {
+    return Promise.reject(err);
+  }
+}

--- a/modules/api/user/search/Request.ts
+++ b/modules/api/user/search/Request.ts
@@ -1,0 +1,7 @@
+export interface UserSearchRequest {
+  // intern
+  id?: string;
+
+  // public
+  name?: string;
+}

--- a/modules/api/user/search/Search.ts
+++ b/modules/api/user/search/Search.ts
@@ -1,0 +1,35 @@
+import { API } from "@/modules/api/user/API";
+import { UserSearchRequest } from "@/modules/api/user/search/Request";
+import { UserSearchResponse } from "@/modules/api/user/search/Response";
+
+export async function UserSearch(tok: string, req: UserSearchRequest[]): Promise<UserSearchResponse[]> {
+  try {
+    const cal = await API.search(
+      {
+        object: req.map((x) => ({
+          intern: {
+            id: x.id || "",
+          },
+          public: {
+            name: x.name || "",
+          },
+        })),
+      },
+      {
+        meta: tok ? { authorization: "Bearer " + tok } : {},
+      },
+    );
+
+    return cal.response.object.map((x) => ({
+      // intern
+      created: x.intern?.created || "",
+      id: x.intern?.id || "",
+
+      //public
+      image: x.public?.image || "",
+      name: x.public?.name || "",
+    }));
+  } catch (err) {
+    return Promise.reject(err);
+  }
+}

--- a/modules/claim/object/ClaimObject.ts
+++ b/modules/claim/object/ClaimObject.ts
@@ -5,6 +5,7 @@ import { ClaimOption, ParseClaimOption } from "@/modules/claim/object/ClaimOptio
 import { PostSearchResponse } from "@/modules/api/post/search/Response";
 import { SplitList } from "@/modules/string/SplitList";
 import { UserObject } from "@/modules/user/object/UserObject";
+import { UserSearchResponse } from "@/modules/api/user/search/Response";
 
 export class ClaimObject {
   private claimOption: ClaimOption;
@@ -12,7 +13,7 @@ export class ClaimObject {
   private post: PostSearchResponse;
   private user: UserObject;
 
-  constructor(post: PostSearchResponse) {
+  constructor(post: PostSearchResponse, user: UserSearchResponse) {
     if (post.kind !== "claim") {
       throw Error(`The claim object requires the provided post kind to be "claim". Post kind "${post.kind}" was given instead.`);
     }
@@ -21,7 +22,7 @@ export class ClaimObject {
       this.claimOption = ParseClaimOption(post.option);
       this.claimStake = CalculateClaimStake(post.stake, this.claimOption);
       this.post = post;
-      this.user = new UserObject({ created: "", id: "8236427635", image: "", name: "RevengeArch47" }); // TODO
+      this.user = new UserObject(user);
     }
   }
 

--- a/modules/claim/object/ClaimStake.ts
+++ b/modules/claim/object/ClaimStake.ts
@@ -15,7 +15,7 @@ export interface ClaimStake {
 // information for the given claim and returns an object of relevant staking
 // information in structured form. The inline comments below are based on the
 // following apischema formatted string value, where, as a reminder, the format
-// is "agreement,disagree,minimum,initial,user".
+// is "agreement,disagreement,minimum,initial,user".
 //
 //     "15.273,2.773,0.5,0.5,1.5"
 //
@@ -25,13 +25,13 @@ export const CalculateClaimStake = (stk: string, opt: ClaimOption): ClaimStake =
   });
 
   let claimStake: ClaimStake = {
-    agree: num[0],
-    disagree: num[1],
-    initial: num[3],
-    minimum: num[2],
+    agree: num[0] || 0,
+    disagree: num[1] || 0,
+    initial: num[3] || 0,
+    minimum: num[2] || 0,
     probability: 0,
     upside: 0,
-    user: num[4],
+    user: num[4] || 0,
   };
 
   // Calculate the probability as the fraction of staked reputation that agrees

--- a/modules/string/HasDuplicate.ts
+++ b/modules/string/HasDuplicate.ts
@@ -1,0 +1,15 @@
+export const HasDuplicate = (lis: string[]): boolean => {
+  const see = new Set<string>();
+
+  for (const x of lis) {
+    if (see.has(x)) {
+      return true;
+    }
+
+    {
+      see.add(x);
+    }
+  }
+
+  return false;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@radix-ui/react-hover-card": "^1.1.1",
         "@radix-ui/react-separator": "^1.1.0",
         "@radix-ui/react-toast": "^1.2.1",
-        "@uvio-network/apitscode": "github:uvio-network/apitscode#v0.1.0",
+        "@uvio-network/apitscode": "github:uvio-network/apitscode#v0.1.1",
         "moment": "^2.30.1",
         "next": "14.2.5",
         "react": "^18",
@@ -3421,8 +3421,8 @@
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
     },
     "node_modules/@uvio-network/apitscode": {
-      "version": "v0.1.0",
-      "resolved": "git+ssh://git@github.com/uvio-network/apitscode.git#501d247aba6bedb0f76c921165db8fd2d069a206",
+      "version": "v0.1.1",
+      "resolved": "git+ssh://git@github.com/uvio-network/apitscode.git#a7d36e584e1e07973dd427e217b49c788a7fa0b4",
       "license": "MIT",
       "dependencies": {
         "@protobuf-ts/plugin": "^2.9.3",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@radix-ui/react-hover-card": "^1.1.1",
     "@radix-ui/react-separator": "^1.1.0",
     "@radix-ui/react-toast": "^1.2.1",
-    "@uvio-network/apitscode": "github:uvio-network/apitscode#v0.1.0",
+    "@uvio-network/apitscode": "github:uvio-network/apitscode#v0.1.1",
     "moment": "^2.30.1",
     "next": "14.2.5",
     "react": "^18",


### PR DESCRIPTION
- We rewrite the user data management for our internal user store since the message passing here was buggy before.
- We update the client library of our generated code and use it to fetch data from our apiserver.
- We redirect to a dedicated claim page when a claim got proposed. This still looks buggy and needs more iteration.
- The whole data fetching magic depends on the render states of the react components. Multiple renders cause multiple fetches where this should not be necessary. We need to check how to do this properly. Hashtag fuck my life.