### PR TITLE
support pagination in post.API/Search

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,13 @@
+"use client";
+
+import { ClaimList } from "@/components/claim/ClaimList";
 import { PageHeader } from "@/components/page/PageHeader";
 
 export default function Page() {
   return (
     <>
       <PageHeader titl="Latest Claims" />
+      <ClaimList request={[{ time: "latest" }]} />
     </>
   );
 };

--- a/modules/api/post/search/Search.ts
+++ b/modules/api/post/search/Search.ts
@@ -6,6 +6,7 @@ export async function PostSearch(tok: string, req: PostSearchRequest[]): Promise
   try {
     const cal = await API.search(
       {
+        filter: req[0].time === "latest" ? { paging: { kind: "page", start: "0", stop: "49" } } : {},
         object: req.map((x) => ({
           intern: {
             id: x.id || "",

--- a/modules/app/claim/propose/form/SubmitForm.ts
+++ b/modules/app/claim/propose/form/SubmitForm.ts
@@ -31,6 +31,7 @@ export const SubmitForm = async (cb: (id: string) => void) => {
     }
   }
 
+  // TODO limit character set for labels, make it alpha numerical
   {
     if (!editor.labels || editor.labels === "") {
       return ToastSender.Error("The proposed claim must have at least one category label.");


### PR DESCRIPTION
With support of https://github.com/uvio-network/apiserver/pull/14, this PR allows us to search for the latest claims in reverse chronological order. For now we have the latest 50 claims hard coded. This can later be improved to load more pages of the latest claims. 