### PR TITLE
ensure claim label format when proposing claims

### DIFF
--- a/components/app/claim/propose/preview/LabelsPreview.tsx
+++ b/components/app/claim/propose/preview/LabelsPreview.tsx
@@ -7,7 +7,7 @@ export const LabelsPreview = () => {
 
   return (
     <LabelList
-      labels={SplitList(editor.labels).map(str => str.toLowerCase())}
+      labels={SplitList(editor.labels).map((str) => str.toLowerCase().replace(/\s+/g, "-"))}
       lifecycle="propose"
       target="_blank"
     />

--- a/modules/app/claim/propose/form/SubmitForm.ts
+++ b/modules/app/claim/propose/form/SubmitForm.ts
@@ -31,15 +31,20 @@ export const SubmitForm = async (cb: (id: string) => void) => {
     }
   }
 
-  // TODO limit character set for labels, make it alpha numerical
   {
+    const exp = /^[a-zA-Z0-9-\s]+$/;
+    const lis = SplitList(editor.labels);
+
+    if (!lis.every((x) => exp.test(x))) {
+      return ToastSender.Error("The format for the claim labels must be alpha numerical.");
+    }
     if (!editor.labels || editor.labels === "") {
       return ToastSender.Error("The proposed claim must have at least one category label.");
     }
-    if (SplitList(editor.labels).length > 4) {
+    if (lis.length > 4) {
       return ToastSender.Error("The proposed claim must not have more than four category labels.");
     }
-    if (HasDuplicate(SplitList(editor.labels))) {
+    if (HasDuplicate(lis)) {
       return ToastSender.Error("The proposed claim must not have duplicated category labels.");
     }
   }


### PR DESCRIPTION
This is just a small verification for the label names. The apiserver will reject claims with an invalid format too. We try to preview most common label names. The current approach is not rock solid, but it is good enough to move on now.

<img width="488" alt="Screenshot 2024-08-01 at 22 07 30" src="https://github.com/user-attachments/assets/e247dea2-5225-4f81-aa83-b8f8e1852d95">

---

<img width="488" alt="Screenshot 2024-08-01 at 22 07 33" src="https://github.com/user-attachments/assets/0174feb1-2538-4b6f-a8bd-580b17974201">
