### PR TITLE
adjust for test data

### DIFF
--- a/components/claim/ClaimFooterCard.tsx
+++ b/components/claim/ClaimFooterCard.tsx
@@ -12,7 +12,7 @@ interface Props {
 
 export const ClaimFooterCard = (props: Props) => {
   const probability = props.votes.probability.toFixed(0);
-  const total = props.votes.agreement + props.votes.disagreement;
+  const total = (props.votes.agreement + props.votes.disagreement).toFixed(2);
 
   const stakeAgree = props.upside.stake[0];
   const stakeDisagree = props.upside.stake[1];

--- a/components/claim/ClaimHeader.tsx
+++ b/components/claim/ClaimHeader.tsx
@@ -1,6 +1,7 @@
 import { ClaimHeaderMenu } from "@/components/claim/ClaimHeaderMenu";
 import { ClaimObject } from "@/modules/claim/object/ClaimObject";
 import { StarLineIcon } from "@/components/icon/StarLineIcon";
+import Link from "next/link";
 
 interface Props {
   claim: ClaimObject;
@@ -9,8 +10,10 @@ interface Props {
 export const ClaimHeader = (props: Props) => {
   return (
     <div className="flex">
-      <div className="flex-none w-12 h-12 mr-2 rounded background-overlay border border-color">
-        {props.claim.owner().image()}
+      <div className="flex-none w-12 h-12 mr-2 rounded background-overlay border border-color overflow-hidden">
+        <Link href="/">
+          <img src={props.claim.owner().image()} />
+        </Link>
       </div>
       <div className="flex-1 w-full">
         <div className="font-medium">

--- a/modules/app/claim/propose/form/SubmitForm.ts
+++ b/modules/app/claim/propose/form/SubmitForm.ts
@@ -31,8 +31,8 @@ export const SubmitForm = async (suc: (pos: string, vot: string) => void) => {
     if (editor.markdown.length <= 100) {
       return ToastSender.Error("The provided markdown must at least have 100 characters.");
     }
-    if (editor.markdown.length >= 2500) {
-      return ToastSender.Error("The provided markdown must not be longer than 2500 characters.");
+    if (editor.markdown.length >= 5000) {
+      return ToastSender.Error("The provided markdown must not be longer than 5000 characters.");
     }
   }
 


### PR DESCRIPTION
Now that we can generate test data the frontend shows a bunch of claims and vote information. In this PR here we fix some minor issues that came up once we saw the frontend rendered with more useful data underneath.

<img width="601" alt="Screenshot 2024-08-05 at 22 39 29" src="https://github.com/user-attachments/assets/86e6220e-3600-47fc-b595-0e7d4e3fe44b">

---

<img width="601" alt="Screenshot 2024-08-05 at 22 40 45" src="https://github.com/user-attachments/assets/22c898d9-e3ac-4fab-b52f-0d65f2aad8bc">

---

<img width="601" alt="Screenshot 2024-08-05 at 22 39 57" src="https://github.com/user-attachments/assets/0b0fa402-8d4e-400d-bd63-7818dd96cc87">

---

<img width="601" alt="Screenshot 2024-08-05 at 22 40 28" src="https://github.com/user-attachments/assets/9abc9def-e937-4d81-b33a-43d405973a99">
