### PR TITLE
shorten claims on timeline

### DIFF
--- a/components/app/claim/propose/preview/MarkdownPreview.tsx
+++ b/components/app/claim/propose/preview/MarkdownPreview.tsx
@@ -7,7 +7,7 @@ export const MarkdownPreview = () => {
   return (
     <div className="w-full min-h-96">
       <RenderMarkdown
-        text={editor.markdown}
+        markdown={editor.markdown}
       />
     </div>
   );

--- a/components/claim/ClaimActions.tsx
+++ b/components/claim/ClaimActions.tsx
@@ -9,8 +9,10 @@ import { ClaimFooter } from "@/components/claim/ClaimFooter";
 import { ClaimLabels } from "@/components/claim/ClaimLabels";
 import { ClaimUpside } from "@/modules/claim/object/ClaimUpside";
 import { ClaimVotes } from "@/modules/claim/object/ClaimVotes";
+import { usePathname } from "next/navigation";
 
 interface Props {
+  claim: string;
   labels: string[];
   lifecycle: string;
   token: string;
@@ -20,6 +22,8 @@ interface Props {
 
 export const ClaimActions = (props: Props) => {
   const [open, setOpen] = React.useState<string>("");
+
+  const isClaimPage = usePathname() === "/claim/" + props.claim ? true : false;
 
   return (
     // This relative container is the anchor for elements inside of the
@@ -34,27 +38,41 @@ export const ClaimActions = (props: Props) => {
         ${open !== "" ? "background-overlay border-color rounded" : "border-background"}
       `}
     >
-      <ClaimLabels
-        labels={props.labels}
-        lifecycle={props.lifecycle}
-      />
+      {isClaimPage && (
+        <ClaimLabels
+          labels={props.labels}
+          lifecycle={props.lifecycle}
+        />
+      )}
 
+      {/*
+      We show the horizontal separator on every page. On the claim page we show
+      the claim labels and the claim buttons. Those additional elements have
+      margin definitions, that together with the margin of the rendered markdown
+      elements cause the claim footer to be more or less far away from the rest
+      of the claim content. So on the claim page, we use the default margin of
+      the horizontal separator, but on every other page, we restrict the
+      separator margin in a way that the claim content and the clainm footer are
+      about an equal distance to one another.
+      */}
       <div className="px-2">
-        <Separator.Horizontal />
+        <Separator.Horizontal margin={isClaimPage ? "" : "mt-0 mb-2"} />
       </div>
 
-      <ClaimButtons
-        open={open}
-        setOpen={setOpen}
-        token={props.token}
-        votes={props.votes}
-      />
+      {isClaimPage && (
+        <ClaimButtons
+          open={open}
+          setOpen={setOpen}
+          token={props.token}
+          votes={props.votes}
+        />
+      )}
 
       <ClaimFooter
         token={props.token}
         upside={props.upside}
         votes={props.votes}
       />
-    </div>
+    </div >
   );
 };

--- a/components/claim/ClaimActions.tsx
+++ b/components/claim/ClaimActions.tsx
@@ -73,6 +73,6 @@ export const ClaimActions = (props: Props) => {
         upside={props.upside}
         votes={props.votes}
       />
-    </div >
+    </div>
   );
 };

--- a/components/claim/ClaimContainer.tsx
+++ b/components/claim/ClaimContainer.tsx
@@ -16,6 +16,7 @@ export const ClaimContainer = (props: Props) => {
       </div>
 
       <ClaimActions
+        claim={props.claim.id()}
         labels={props.claim.labels()}
         lifecycle={props.claim.lifecycle()}
         token={props.claim.token()}

--- a/components/claim/ClaimContent.tsx
+++ b/components/claim/ClaimContent.tsx
@@ -1,8 +1,12 @@
+"use client";
+
 import * as React from "react";
 
 import { ClaimObject } from "@/modules/claim/object/ClaimObject";
 import { RenderMarkdown } from "@/components/markdown/RenderMarkdown";
+import { usePathname } from "next/navigation";
 import { useRouter } from "next/navigation";
+import { LimitMarkdown } from "@/modules/string/LimitMarkdown";
 
 interface Props {
   claim: ClaimObject;
@@ -10,19 +14,36 @@ interface Props {
 
 export const ClaimContent = (props: Props) => {
   const router = useRouter();
+  const pathname = usePathname();
+
+  const claimPage = "/claim/" + props.claim.id();
+
+  const process = (txt: string): string => {
+    if (pathname === claimPage) {
+      return txt;
+    }
+
+    const lim = LimitMarkdown(txt);
+
+    if (lim.cut === true) {
+      return lim.txt + `[ ... show more](${claimPage})`;
+    }
+
+    return txt;
+  };
 
   const onClick = (e: React.MouseEvent) => {
     const t = e.target as HTMLElement;
 
     if (t.tagName === "A") return;
 
-    router.push("/claim/" + props.claim.id());
+    router.push(claimPage);
   };
 
   return (
     <div className="" onClick={onClick}>
       <RenderMarkdown
-        text={props.claim.markdown()}
+        markdown={process(props.claim.markdown())}
       />
     </div>
   );

--- a/components/claim/ClaimHeader.tsx
+++ b/components/claim/ClaimHeader.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link";
 
+import * as ToastSender from "@/components/toast/ToastSender";
+
 import { ClaimHeaderMenu } from "@/components/claim/ClaimHeaderMenu";
 import { ClaimObject } from "@/modules/claim/object/ClaimObject";
 import { StarLineIcon } from "@/components/icon/StarLineIcon";
@@ -10,6 +12,10 @@ interface Props {
 
 export const ClaimHeader = (props: Props) => {
   const image = props.claim.owner().image();
+
+  const onClick = () => {
+    ToastSender.Info("It's comming just chill ok!");
+  };
 
   return (
     <div className="flex">
@@ -39,11 +45,11 @@ export const ClaimHeader = (props: Props) => {
         </div>
       </div>
       <div className="flex-none">
-        <div>
+        <div className="h-6">
           <ClaimHeaderMenu claim={props.claim} />
         </div>
-        <div>
-          <button type="button">
+        <div className="h-6">
+          <button type="button" onClick={onClick}>
             <StarLineIcon size="w-6 h-6" />
           </button>
         </div>

--- a/components/claim/ClaimHeaderMenu.tsx
+++ b/components/claim/ClaimHeaderMenu.tsx
@@ -1,4 +1,5 @@
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+import * as ToastSender from "@/components/toast/ToastSender";
 
 import { ClaimObject } from "@/modules/claim/object/ClaimObject";
 import { MenuHorizontalIcon } from "@/components/icon/MenuHorizontalIcon";
@@ -14,6 +15,10 @@ const itemClassName = `
 `;
 
 export const ClaimHeaderMenu = (props: Props) => {
+  const onClick = () => {
+    ToastSender.Info("It's comming just chill ok!");
+  };
+
   return (
     <DropdownMenu.Root>
       <DropdownMenu.Trigger asChild>
@@ -35,16 +40,16 @@ export const ClaimHeaderMenu = (props: Props) => {
           `}
           sideOffset={5}
         >
-          <DropdownMenu.Item className={itemClassName}>
+          <DropdownMenu.Item className={itemClassName} onClick={onClick}>
             Adjourn
           </DropdownMenu.Item>
-          <DropdownMenu.Item className={itemClassName}>
+          <DropdownMenu.Item className={itemClassName} onClick={onClick}>
             Dispute
           </DropdownMenu.Item>
-          <DropdownMenu.Item className={itemClassName}>
+          <DropdownMenu.Item className={itemClassName} onClick={onClick}>
             Nullify
           </DropdownMenu.Item>
-          <DropdownMenu.Item className={itemClassName}>
+          <DropdownMenu.Item className={itemClassName} onClick={onClick}>
             Resolve
           </DropdownMenu.Item>
         </DropdownMenu.Content>

--- a/components/layout/separator.tsx
+++ b/components/layout/separator.tsx
@@ -1,16 +1,27 @@
 import * as Separator from "@radix-ui/react-separator";
 
-export const Horizontal = () => {
+interface Props {
+  margin?: string;
+}
+
+export const Horizontal = (props: Props) => {
   return (
     <Separator.Root
-      className="my-4 border-t-[1px] border-color data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px"
+      className={`
+        border-t-[1px] border-color
+        ${props.margin ? props.margin : "my-4"}
+        data-[orientation=horizontal]:h-px
+        data-[orientation=horizontal]:w-full
+        data-[orientation=vertical]:h-full
+        data-[orientation=vertical]:w-px
+      `}
       decorative
       orientation="horizontal"
     />
   );
 };
 
-export const Vertical = () => {
+export const Vertical = (props: Props) => {
   return (
     <Separator.Root
       className="mx-auto border-r-[1px] border-color border-dashed data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px"

--- a/components/markdown/RenderMarkdown.tsx
+++ b/components/markdown/RenderMarkdown.tsx
@@ -1,10 +1,11 @@
+import Link from "next/link";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
 import { Components } from "react-markdown";
 
 interface Props {
-  text: string;
+  markdown: string;
 }
 
 export const RenderMarkdown = (props: Props) => {
@@ -16,7 +17,7 @@ export const RenderMarkdown = (props: Props) => {
       remarkPlugins={[remarkGfm]}
       skipHtml={true}
     >
-      {props.text}
+      {props.markdown}
     </Markdown>
   );
 };
@@ -41,16 +42,30 @@ const components: Components = {
     return <h5 className="my-4 text-black dark:text-white text-xl" {...getRst(props)} />
   },
   a(props) {
-    return <a className="my-4 text-blue-400" target="_blank" {...getRst(props)} />
+    // We are parsing links provided with the markdown and want to ensure that
+    // external links open in a new browser tab. It may happen that links are
+    // injected that point to app specific pages. For instance our own internal
+    // " ... show more" link points to the specific claim page at which all
+    // content can be read without truncation. For our internal links we do not
+    // want to open new browser tabs, but instead allow the user to stay where
+    // they are. That is why the link target below is conditional on the href
+    // atribute of the parsed link.
+    //
+    // Further note that we are using the next/link component for all parsed
+    // links. We are doing that in order to using the NextJs native navigation
+    // for internal links. If we were to use plain <a> elements here, then our
+    // internat " ... show more" links would reload the entire app only to get
+    // to the specified claim page. And we do not want that behaviour.
+    return <Link className="text-blue-400" target={props.href?.startsWith("/claim/") ? "" : "_blank"} {...getRst(props)} />
   },
   p(props) {
-    return <p className="my-4" {...getRst(props)} />
+    return <p className="mt-4" {...getRst(props)} />
   },
   ol(props) {
-    return <ol className="my-4 list-decimal list-inside" {...getRst(props)} />
+    return <ol className="mt-4 list-decimal list-inside" {...getRst(props)} />
   },
   ul(props) {
-    return <ul className="my-4 list-disc list-inside" {...getRst(props)} />
+    return <ul className="mt-4 list-disc list-inside" {...getRst(props)} />
   },
   li(props) {
     return <li className="ml-2" {...getRst(props)} />

--- a/components/sidebar/button/ProposeButton.tsx
+++ b/components/sidebar/button/ProposeButton.tsx
@@ -1,31 +1,33 @@
 "use client";
 
+import Link from "next/link";
+
 import * as ToastSender from "@/components/toast/ToastSender";
 
 import { AuthStore } from "@/components/auth/AuthStore";
 import { BaseButton } from "@/components/button/BaseButton";
 import { AddSquareIcon } from "@/components/icon/AddSquareIcon";
-import { useRouter } from "next/navigation";
 import { useShallow } from "zustand/react/shallow";
 
 export const ProposeButton = () => {
   const { valid } = AuthStore(useShallow((state) => ({ valid: state.auth.valid })));
 
-  const router = useRouter();
-
-  const onClick = () => {
-    if (valid) {
-      router.push("/claim/propose");
-    } else {
+  const onClick = (e: React.MouseEvent) => {
+    if (!valid) {
+      e.preventDefault();
       ToastSender.Info("You need to login to propose a claim!");
     }
   };
 
   return (
-    <BaseButton
+    <Link
+      href="/claim/propose"
       onClick={onClick}
-      icon={<AddSquareIcon />}
-      text="Propose Claim"
-    />
+    >
+      <BaseButton
+        icon={<AddSquareIcon />}
+        text="Propose Claim"
+      />
+    </Link>
   );
 };

--- a/modules/string/LimitMarkdown.ts
+++ b/modules/string/LimitMarkdown.ts
@@ -1,0 +1,20 @@
+const lim = 70;
+
+export const LimitMarkdown = (txt: string): { txt: string; cut: boolean } => {
+  let tot = 0;
+  let out = "";
+
+  for (const x of txt.split("\n")) {
+    const spl = x.trim().split(/\s+/);
+
+    if (tot + spl.length > lim) {
+      out += spl.slice(0, lim - tot).join(" ") + "\n";
+      return { txt: out.trim(), cut: true };
+    }
+
+    out += x + "\n";
+    tot += spl.length;
+  }
+
+  return { txt: out.trim(), cut: false };
+};


### PR DESCRIPTION
Here we truncate claims on the timeline view in a way that claim labels and claim buttons are removed, as well as the claim markdown being cut off at around 65 words. Clicking on the markdown or the ` ... show more` link redirects the user to the specific claim page. There all content is expanded and the claim labels as well as the claim buttons are shown for further interactions.

<img width="601" alt="Screenshot 2024-08-06 at 16 06 25" src="https://github.com/user-attachments/assets/a1d0f842-e719-495b-bbbd-6978836a3352">

---

<img width="601" alt="Screenshot 2024-08-06 at 16 06 42" src="https://github.com/user-attachments/assets/32ffb156-d6d6-484e-9e98-884d107a6299">





fixes https://github.com/uvio-network/issues/issues/8