### PR TITLE
do not show probabilities on comments

### DIFF
--- a/components/button/NoButton.tsx
+++ b/components/button/NoButton.tsx
@@ -1,41 +1,32 @@
 import * as React from "react";
 
 interface Props {
-  disabled?: boolean;
   font?: string;
-  hover?: string;
-  onClick?: (eve: React.MouseEvent<HTMLButtonElement>) => void;
-  position?: string;
+  position?: string; // text position, either left or right from the icon
   icon: React.ReactElement;
   text?: string;
 }
 
-export const BaseButton = (props: Props) => {
+export const NoButton = (props: Props) => {
   return (
-    <button
+    <div
       className={`
-        flex p-2 w-full h-fit items-center rounded-lg outline-none group
+        flex p-2 w-full h-fit items-center rounded-lg outline-none
         text-sm sm:text-base text-gray-400 dark:text-gray-500 whitespace-nowrap
         ${props.font ? props.font : "font-medium"}
-        ${props.disabled ? "opacity-50" : props.hover ? props.hover : "enabled:hover:text-black enabled:dark:hover:text-white enabled:hover:bg-gray-200 enabled:dark:hover:bg-gray-700"}
       `}
-      disabled={props.disabled}
-      onClick={props.onClick}
-      type="button"
     >
       {props.text && props.text !== "" && props.position === "left" && (
         <div className="my-auto mr-2">
           {props.text}
         </div>
       )}
-      {props.icon && React.cloneElement(props.icon, {
-        disabled: props.disabled,
-      })}
+      {props.icon && React.cloneElement(props.icon, {})}
       {props.text && props.text !== "" && (!props.position || props.position === "right") && (
         <div className="my-auto ml-2">
           {props.text}
         </div>
       )}
-    </button >
+    </div >
   );
 };

--- a/components/claim/ClaimActions.tsx
+++ b/components/claim/ClaimActions.tsx
@@ -7,24 +7,17 @@ import * as Separator from "@/components/layout/separator";
 import { ClaimButtons } from "@/components/claim/ClaimButtons";
 import { ClaimFooter } from "@/components/claim/ClaimFooter";
 import { ClaimLabels } from "@/components/claim/ClaimLabels";
-import { ClaimUpside } from "@/modules/claim/object/ClaimUpside";
-import { ClaimVotes } from "@/modules/claim/object/ClaimVotes";
+import { ClaimObject } from "@/modules/claim/object/ClaimObject";
 import { usePathname } from "next/navigation";
 
 interface Props {
-  claim: string;
-  kind: string;
-  labels: string[];
-  lifecycle: string;
-  token: string;
-  upside: ClaimUpside;
-  votes: ClaimVotes;
+  claim: ClaimObject;
 }
 
 export const ClaimActions = (props: Props) => {
   const [open, setOpen] = React.useState<string>("");
 
-  const isClaim = props.kind === "claim";
+  const isClaim = props.claim.kind() === "claim";
   const isPage = usePathname() === "/claim/" + props.claim ? true : false;
 
   return (
@@ -43,8 +36,8 @@ export const ClaimActions = (props: Props) => {
     >
       {isClaim && isPage && (
         <ClaimLabels
-          labels={props.labels}
-          lifecycle={props.lifecycle}
+          labels={props.claim.labels()}
+          lifecycle={props.claim.lifecycle()}
         />
       )}
 
@@ -69,15 +62,11 @@ export const ClaimActions = (props: Props) => {
           claim={props.claim}
           open={open}
           setOpen={setOpen}
-          token={props.token}
-          votes={props.votes}
         />
       )}
 
       <ClaimFooter
-        token={props.token}
-        upside={props.upside}
-        votes={props.votes}
+        claim={props.claim}
       />
     </div>
   );

--- a/components/claim/ClaimButtons.tsx
+++ b/components/claim/ClaimButtons.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 
-import { ClaimVotes } from "@/modules/claim/object/ClaimVotes";
+import { ClaimObject } from "@/modules/claim/object/ClaimObject";
 import { EditorOverlay } from "@/components/app/claim/stake/editor/EditorOverlay";
 import { EditorStore } from "@/components/app/claim/stake/editor/EditorStore";
 import { QueryStore } from "@/modules/query/QueryStore";
@@ -11,11 +11,9 @@ import { SubmitButton } from "@/components/app/claim/stake/editor/SubmitButton";
 import { ValueField } from "@/components/app/claim/stake/field/ValueField";
 
 interface Props {
-  claim: string;
+  claim: ClaimObject;
   open: string;
   setOpen: (open: string) => void;
-  token: string;
-  votes: ClaimVotes;
 }
 
 export const ClaimButtons = (props: Props) => {
@@ -26,9 +24,9 @@ export const ClaimButtons = (props: Props) => {
     if (props.open === "") {
       editor.delete();
     } else {
-      editor.updateClaim(props.claim)
-      editor.updateMinimum(props.votes.minimum)
-      editor.updateToken(props.token)
+      editor.updateClaim(props.claim.id())
+      editor.updateMinimum(props.claim.votes().minimum)
+      editor.updateToken(props.claim.token())
     }
   }, [props.open, editor]);
 
@@ -45,8 +43,8 @@ export const ClaimButtons = (props: Props) => {
             <div className="w-full mr-2">
               <ValueField
                 setOpen={props.setOpen}
-                token={props.token}
-                votes={props.votes}
+                token={props.claim.token()}
+                votes={props.claim.votes()}
               />
             </div>
 

--- a/components/claim/ClaimContainer.tsx
+++ b/components/claim/ClaimContainer.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { ClaimActions } from "@/components/claim/ClaimActions";
 import { ClaimContent } from "@/components/claim/ClaimContent";
 import { ClaimHeader } from "@/components/claim/ClaimHeader";
@@ -9,7 +11,7 @@ interface Props {
 
 export const ClaimContainer = (props: Props) => {
   return (
-    <div className="mb-8">
+    <div className={`${props.claim.kind() === "claim" ? "mb-6" : "mb-2"}`}>
       <div className="p-2 w-full">
         <ClaimHeader claim={props.claim} />
         <ClaimContent claim={props.claim} />
@@ -25,13 +27,7 @@ export const ClaimContainer = (props: Props) => {
       )}
 
       <ClaimActions
-        claim={props.claim.id()}
-        kind={props.claim.kind()}
-        labels={props.claim.labels()}
-        lifecycle={props.claim.lifecycle()}
-        token={props.claim.token()}
-        upside={props.claim.upside()}
-        votes={props.claim.votes()}
+        claim={props.claim}
       />
     </div>
   );

--- a/components/claim/ClaimFooter.tsx
+++ b/components/claim/ClaimFooter.tsx
@@ -1,48 +1,84 @@
 import { BaseButton } from "@/components/button/BaseButton";
+import { NoButton } from "@/components/button/NoButton";
 import { ClaimFooterCard } from "@/components/claim/ClaimFooterCard";
-import { ClaimUpside } from "@/modules/claim/object/ClaimUpside";
-import { ClaimVotes } from "@/modules/claim/object/ClaimVotes";
+import { ClaimObject } from "@/modules/claim/object/ClaimObject";
 import { TriangleDownIcon } from "@/components/icon/TriangleDownIcon";
 import { TriangleUpIcon } from "@/components/icon/TriangleUpIcon";
 
 interface Props {
-  token: string;
-  upside: ClaimUpside;
-  votes: ClaimVotes;
+  claim: ClaimObject;
 }
 
 export const ClaimFooter = (props: Props) => {
+  const token = props.claim.kind() === "claim" ? props.claim.token() : props.claim.parent()?.token();
+
+  const isClaim = props.claim.kind() === "claim";
+  const isComment = props.claim.kind() === "comment";
+
+  const stakeAgree = isComment && props.claim.votes().agreement !== 0 ? true : false;
+  const stakeDisagree = isComment && props.claim.votes().disagreement !== 0 ? true : false;
+
+  console.log("isClaim", isClaim)
+  console.log("isComment", isComment)
+  console.log("stakeAgree", stakeAgree)
+  console.log("stakeDisagree", stakeDisagree)
+  console.log("upside", props.claim.upside())
+
   return (
     <div className="flex mt-2 px-2">
-      <div className="flex-1 relative">
-        <div className="absolute left-0 w-fit">
-          <BaseButton
-            font="font-normal"
-            icon={<TriangleUpIcon className="mb-[1px]" />}
-            position="right"
-            text={`${props.votes.agreement.toFixed(2)} ${props.token}`}
-          />
+      <div className="flex-1 w-full">
+        <div className="grid place-content-start w-full">
+          <div className="grid place-content-start">
+            {isClaim && (
+              <BaseButton
+                font="font-normal"
+                icon={<TriangleUpIcon className="mb-[1px]" />}
+                position="right"
+                text={`${props.claim.votes().agreement.toFixed(2)} ${token}`}
+              />
+            )}
+
+            {stakeAgree && (
+              <NoButton
+                font="font-normal"
+                icon={<TriangleUpIcon className="mb-[1px]" />}
+                position="right"
+                text={`${props.claim.votes().agreement.toFixed(2)} ${token}`}
+              />
+            )}
+          </div>
         </div>
       </div>
+
+      {isClaim && (
+        <div className="flex-1 w-full">
+          <div className="mx-auto w-fit">
+            <ClaimFooterCard claim={props.claim} />
+          </div>
+        </div>
+      )}
 
       <div className="flex-1 w-full">
-        <div className="mx-auto w-fit">
-          <ClaimFooterCard
-            token={props.token}
-            upside={props.upside}
-            votes={props.votes}
-          />
-        </div>
-      </div>
+        <div className="grid place-content-end w-full">
+          <div className="grid place-content-end">
+            {isClaim && (
+              <BaseButton
+                font="font-normal"
+                icon={<TriangleDownIcon className="mb-[1px]" />}
+                position="left"
+                text={`${props.claim.votes().disagreement.toFixed(2)} ${token}`}
+              />
+            )}
 
-      <div className="flex-1 relative">
-        <div className="absolute right-0 w-fit">
-          <BaseButton
-            font="font-normal"
-            icon={<TriangleDownIcon className="mb-[1px]" />}
-            position="left"
-            text={`${props.votes.disagreement.toFixed(2)} ${props.token}`}
-          />
+            {stakeDisagree && (
+              <NoButton
+                font="font-normal"
+                icon={<TriangleDownIcon className="mb-[1px]" />}
+                position="left"
+                text={`${props.claim.votes().disagreement.toFixed(2)} ${token}`}
+              />
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/components/claim/ClaimFooterCard.tsx
+++ b/components/claim/ClaimFooterCard.tsx
@@ -1,24 +1,26 @@
+"use client";
+
 import * as HoverCard from "@radix-ui/react-hover-card";
 import * as Separator from "@/components/layout/separator";
 
-import { ClaimUpside } from "@/modules/claim/object/ClaimUpside";
-import { ClaimVotes } from "@/modules/claim/object/ClaimVotes";
+import { ClaimObject } from "@/modules/claim/object/ClaimObject";
 
 interface Props {
-  token: string;
-  upside: ClaimUpside;
-  votes: ClaimVotes;
+  claim: ClaimObject;
 }
 
 export const ClaimFooterCard = (props: Props) => {
-  const probability = props.votes.probability.toFixed(0);
-  const total = (props.votes.agreement + props.votes.disagreement).toFixed(2);
+  const hsitg = props.claim.upside().hsitg;
+  const token = props.claim.token();
 
-  const stakeAgree = props.upside.stake[0];
-  const stakeDisagree = props.upside.stake[1];
+  const probability = props.claim.votes().probability.toFixed(0);
+  const total = (props.claim.votes().agreement + props.claim.votes().disagreement).toFixed(2);
 
-  const shareAgree = props.upside.share[0].toFixed(0);
-  const shareDisagree = props.upside.share[1].toFixed(0);
+  const stakeAgree = props.claim.upside().stake[0];
+  const stakeDisagree = props.claim.upside().stake[1];
+
+  const shareAgree = props.claim.upside().share[0].toFixed(0);
+  const shareDisagree = props.claim.upside().share[1].toFixed(0);
 
   return (
     <HoverCard.Root
@@ -45,14 +47,14 @@ export const ClaimFooterCard = (props: Props) => {
           sideOffset={5}
         >
           <div className="text-gray-500 dark:text-gray-400 text-sm">
-            This claim has a probability of <strong>{probability}%</strong> to be true, based on a total of {total} {props.token} staked.
+            This claim has a probability of <strong>{probability}%</strong> to be true, based on a total of {total} {token} staked.
 
             {stakeAgree !== 0 && (
               <div>
                 <Separator.Horizontal />
 
                 <div>
-                  You have {stakeAgree} {props.token} staked in <strong>agreement</strong> with the claim&apos;s statement.
+                  You have {stakeAgree} {token} staked in <strong>agreement</strong> with the claim&apos;s statement.
 
                   <br /><br />
 
@@ -66,7 +68,7 @@ export const ClaimFooterCard = (props: Props) => {
                 <Separator.Horizontal />
 
                 <div>
-                  You have {stakeDisagree} {props.token} staked in <strong>disagreement</strong> with the claim&apos;s statement.
+                  You have {stakeDisagree} {token} staked in <strong>disagreement</strong> with the claim&apos;s statement.
 
                   <br /><br />
 
@@ -75,7 +77,7 @@ export const ClaimFooterCard = (props: Props) => {
               </div>
             )}
 
-            {props.upside.hsitg === false && (
+            {hsitg === false && (
               <div>
                 <Separator.Horizontal />
 


### PR DESCRIPTION
Towards https://github.com/uvio-network/issues/issues/2. The first two screenshots below show comments on the timeline in either light theme or dark mode. The comments show a minimized version of the referenced claim and indicate how much reputation the commenting user has staked on the referenced claim. Clicking on either the comment or the embedded claim redirects the user to either page respectively.


<img width="601" alt="Screenshot 2024-08-08 at 13 19 32" src="https://github.com/user-attachments/assets/d8dc7c65-4601-4b22-8919-64ef07ce87db">

---

<img width="601" alt="Screenshot 2024-08-08 at 13 20 01" src="https://github.com/user-attachments/assets/922d2b01-b71f-4b4a-a7a7-0ee767c29746">

---

As can be seen below, posts that are not comments, but claims, show probabilities and stake on either side of the bet after all. 

<img width="601" alt="Screenshot 2024-08-08 at 13 20 28" src="https://github.com/user-attachments/assets/a61e7122-11e2-4aae-a9aa-b469a4c7ba1f">

---

<img width="601" alt="Screenshot 2024-08-08 at 13 20 55" src="https://github.com/user-attachments/assets/21db2d83-a043-4986-b9e0-9e0569eed74f">
