### PR TITLE
show simplified comments underneath claims on claim page

### DIFF
--- a/app/claim/[slug]/page.tsx
+++ b/app/claim/[slug]/page.tsx
@@ -8,7 +8,7 @@ export default function Page({ params }: { params: { slug: string } }) {
     <>
       <PageHeader titl="Claim object" />
       <ClaimList
-        page={true}
+        page={params.slug}
         query={["claim", "id", params.slug]}
         request={[{ id: params.slug }]}
       />

--- a/components/button/BaseButton.tsx
+++ b/components/button/BaseButton.tsx
@@ -5,7 +5,7 @@ interface Props {
   font?: string;
   hover?: string;
   onClick?: (eve: React.MouseEvent<HTMLButtonElement>) => void;
-  position?: string;
+  position?: string; // text position, either left or right from the icon
   icon: React.ReactElement;
   text?: string;
 }

--- a/components/claim/ClaimContainer.tsx
+++ b/components/claim/ClaimContainer.tsx
@@ -18,6 +18,13 @@ export const ClaimContainer = (props: Props) => {
         <ClaimContent claim={props.claim} />
       </div>
 
+      {/*
+      We want to render embedded claims for every comment, if embedding is
+      enabled by the caller. For instance, we do not want to embed parent claims
+      when rendering comments on the claim page, because the parent claim is
+      already rendered at the top of the claim page. And so in this case, we
+      want to only render comments in a simplified version, without embedding.
+      */}
       {props.claim.kind() === "comment" && props.embed && (
         <div className="mx-2 mt-2 px-2 pb-2 background-overlay rounded border border-color">
           <ClaimContent

--- a/components/claim/ClaimContainer.tsx
+++ b/components/claim/ClaimContainer.tsx
@@ -7,6 +7,7 @@ import { ClaimObject } from "@/modules/claim/object/ClaimObject";
 
 interface Props {
   claim: ClaimObject;
+  embed: boolean;
 }
 
 export const ClaimContainer = (props: Props) => {
@@ -17,11 +18,11 @@ export const ClaimContainer = (props: Props) => {
         <ClaimContent claim={props.claim} />
       </div>
 
-      {props.claim.kind() === "comment" && (
+      {props.claim.kind() === "comment" && props.embed && (
         <div className="mx-2 mt-2 px-2 pb-2 background-overlay rounded border border-color">
           <ClaimContent
             claim={props.claim.parent()!} // if kind is "comment" then parent() will never be undefined
-            embed={true}
+            embed={props.embed}
           />
         </div>
       )}

--- a/components/claim/ClaimFooter.tsx
+++ b/components/claim/ClaimFooter.tsx
@@ -18,12 +18,6 @@ export const ClaimFooter = (props: Props) => {
   const stakeAgree = isComment && props.claim.votes().agreement !== 0 ? true : false;
   const stakeDisagree = isComment && props.claim.votes().disagreement !== 0 ? true : false;
 
-  console.log("isClaim", isClaim)
-  console.log("isComment", isComment)
-  console.log("stakeAgree", stakeAgree)
-  console.log("stakeDisagree", stakeDisagree)
-  console.log("upside", props.claim.upside())
-
   return (
     <div className="flex mt-2 px-2">
       <div className="flex-1 w-full">

--- a/components/claim/ClaimList.tsx
+++ b/components/claim/ClaimList.tsx
@@ -51,6 +51,15 @@ export const ClaimList = (props: Props) => {
     },
   });
 
+  // We search for posts in all kinds of variations in this component. For one,
+  // we want to always work with a list of posts, even if it is empty. So getLis
+  // does that for us. And then, we have to account for pages rendered with or
+  // without comments. If we are tasked to render a claim page, and the post to
+  // render is in fact a comment, then we remove the parent claim from the
+  // search response in order to only forward the post of kind "comment". Note
+  // that search queries are automatically extended at the moment in order to
+  // provide claims with comments and comments with their parent claims. This
+  // automatic extension is the reason for our filtering efforts here.
   const list = getLis(claims.data, votes.data, props.page || "");
 
   // We want to embed claims on comment posts on basically every page, except on
@@ -90,7 +99,7 @@ export const ClaimList = (props: Props) => {
 };
 
 const getLis = (cla: ClaimObject[] | undefined, vot: VoteObject[] | undefined, pag: string): ClaimObject[] => {
-  if (cla && pag) return selPos(cla, pag);
+  if (cla && pag) return selCom(cla, pag);
   if (cla && !vot) return cla;
   if (cla && vot) return mrgLis(cla, vot);
   return [];
@@ -123,7 +132,7 @@ const mrgLis = (cla: ClaimObject[], vot: VoteObject[]): ClaimObject[] => {
   return lis;
 };
 
-const selPos = (cla: ClaimObject[], pag: string): ClaimObject[] => {
+const selCom = (cla: ClaimObject[], pag: string): ClaimObject[] => {
   for (const x of cla) {
     if (x.kind() === "comment" && x.id() === pag) {
       return [x];


### PR DESCRIPTION
The screenshot doesn't show it too well, but this PR shows simplified comments under claims on the claim page, as the title suggests. This PR closes https://github.com/uvio-network/issues/issues/2. 

<img width="576" alt="Screenshot 2024-08-08 at 16 04 48" src="https://github.com/user-attachments/assets/c212b507-2219-4c89-a0e0-670326980f94">
