### PR TITLE
add EffectButton for reusable effect management

### DIFF
--- a/app/effects.css
+++ b/app/effects.css
@@ -1,0 +1,37 @@
+.dark .color-effect {
+  /* animate the font color over 1 second, and repeat the animation twice */
+  animation: darkFontColorAnimation 250ms 2;
+}
+
+@keyframes darkFontColorAnimation {
+  0% {
+    color: inherit;
+  }
+
+  50% {
+    color: white;
+  }
+
+  100% {
+    color: inherit;
+  }
+}
+
+.light .color-effect {
+  /* animate the font color over 1 second, and repeat the animation twice */
+  animation: lightFontColorAnimation 250ms 2;
+}
+
+@keyframes lightFontColorAnimation {
+  0% {
+    color: inherit;
+  }
+
+  50% {
+    color: black;
+  }
+
+  100% {
+    color: inherit;
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import "@/app/effects.css";
 import "@/app/globals.css";
 
 import { AppProvider } from "@/components/app/AppProvider";

--- a/components/button/BaseButton.tsx
+++ b/components/button/BaseButton.tsx
@@ -1,7 +1,10 @@
 import * as React from "react";
 
+import { EffectButton } from "@/components/button/EffectButton";
+
 interface Props {
   disabled?: boolean;
+  effect?: boolean;
   font?: string;
   hover?: string;
   onClick?: (eve: React.MouseEvent<HTMLButtonElement>) => void;
@@ -11,10 +14,30 @@ interface Props {
 }
 
 export const BaseButton = (props: Props) => {
+  const render = (props: Props) => {
+    return (
+      <>
+        {props.text && props.text !== "" && props.position === "left" && (
+          <div className="my-auto mr-2">
+            {props.text}
+          </div>
+        )}
+        {props.icon && React.cloneElement(props.icon, {
+          disabled: props.disabled,
+        })}
+        {props.text && props.text !== "" && (!props.position || props.position === "right") && (
+          <div className="my-auto ml-2">
+            {props.text}
+          </div>
+        )}
+      </>
+    );
+  };
+
   return (
     <button
       className={`
-        flex p-2 w-full h-fit items-center rounded-lg outline-none group
+        flex w-full h-fit rounded outline-none group
         text-sm sm:text-base text-gray-400 dark:text-gray-500 whitespace-nowrap
         ${props.font ? props.font : "font-medium"}
         ${props.disabled ? "opacity-50" : props.hover ? props.hover : "enabled:hover:text-black enabled:dark:hover:text-white enabled:hover:bg-gray-200 enabled:dark:hover:bg-gray-700"}
@@ -23,17 +46,13 @@ export const BaseButton = (props: Props) => {
       onClick={props.onClick}
       type="button"
     >
-      {props.text && props.text !== "" && props.position === "left" && (
-        <div className="my-auto mr-2">
-          {props.text}
-        </div>
-      )}
-      {props.icon && React.cloneElement(props.icon, {
-        disabled: props.disabled,
-      })}
-      {props.text && props.text !== "" && (!props.position || props.position === "right") && (
-        <div className="my-auto ml-2">
-          {props.text}
+      {props.effect === true && props.text ? (
+        <EffectButton value={props.text}>
+          {render(props)}
+        </EffectButton>
+      ) : (
+        <div className="flex p-2 rounded items-center">
+          {render(props)}
         </div>
       )}
     </button >

--- a/components/button/EffectButton.tsx
+++ b/components/button/EffectButton.tsx
@@ -9,7 +9,7 @@ interface Props {
   [key: string]: any;
 }
 
-export const EffectButton = React.forwardRef<HTMLDivElement, Props>((props: Props, ref) => {
+export const EffectButton = React.forwardRef<HTMLDivElement, Props>(function EffectButton(props: Props, ref) {
   const [className, setClassName] = React.useState<string>(defaultClass);
   const [currentValue, setCurrentValue] = React.useState<string>(props.value);
 

--- a/components/button/EffectButton.tsx
+++ b/components/button/EffectButton.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+
+const defaultClass = "flex p-2 rounded items-center";
+const effectClass = "color-effect";
+
+interface Props {
+  children: React.ReactNode;
+  value: string;
+  [key: string]: any;
+}
+
+export const EffectButton = React.forwardRef<HTMLDivElement, Props>((props: Props, ref) => {
+  const [className, setClassName] = React.useState<string>(defaultClass);
+  const [currentValue, setCurrentValue] = React.useState<string>(props.value);
+
+  const { children, value, ...rest } = props;
+
+  React.useEffect(() => {
+    if (props.value !== currentValue) {
+      {
+        setClassName(addClassName(className));
+        setCurrentValue(props.value);
+      }
+
+      const timeout = setTimeout(() => {
+        setClassName(defaultClass);
+        clearTimeout(timeout);
+      }, 1000)
+    }
+  }, [props.value, className, currentValue, setClassName, setCurrentValue]);
+
+  return (
+    <div className={className} ref={ref} {...rest}>
+      {children}
+    </div>
+  );
+});
+
+const addClassName = (str: string): string => {
+  const spl = str.split(" ");
+
+  if (!spl.includes(effectClass)) {
+    spl.push(effectClass);
+  }
+
+  return spl.join(" ");
+};

--- a/components/button/NoButton.tsx
+++ b/components/button/NoButton.tsx
@@ -1,30 +1,49 @@
 import * as React from "react";
 
+import { EffectButton } from "@/components/button/EffectButton";
+
 interface Props {
   font?: string;
+  effect?: boolean;
   position?: string; // text position, either left or right from the icon
   icon: React.ReactElement;
   text?: string;
 }
 
 export const NoButton = (props: Props) => {
+  const render = (props: Props) => {
+    return (
+      <>
+        {props.text && props.text !== "" && props.position === "left" && (
+          <div className="my-auto mr-2">
+            {props.text}
+          </div>
+        )}
+        {props.icon && React.cloneElement(props.icon, {})}
+        {props.text && props.text !== "" && (!props.position || props.position === "right") && (
+          <div className="my-auto ml-2">
+            {props.text}
+          </div>
+        )}
+      </>
+    );
+  };
+
   return (
     <div
       className={`
-        flex p-2 w-full h-fit items-center rounded-lg outline-none
+        flex w-full h-fit rounded outline-none
         text-sm sm:text-base text-gray-400 dark:text-gray-500 whitespace-nowrap
         ${props.font ? props.font : "font-medium"}
       `}
     >
-      {props.text && props.text !== "" && props.position === "left" && (
-        <div className="my-auto mr-2">
-          {props.text}
-        </div>
-      )}
-      {props.icon && React.cloneElement(props.icon, {})}
-      {props.text && props.text !== "" && (!props.position || props.position === "right") && (
-        <div className="my-auto ml-2">
-          {props.text}
+      {props.effect === true && props.text ? (
+        <EffectButton value={props.text}>
+          {render(props)}
+        </EffectButton>
+      ) : (
+        <div className="flex p-2 rounded items-center">
+          {render(props)}
         </div>
       )}
     </div >

--- a/components/claim/ClaimButtons.tsx
+++ b/components/claim/ClaimButtons.tsx
@@ -28,7 +28,7 @@ export const ClaimButtons = (props: Props) => {
       editor.updateMinimum(props.claim.votes().minimum)
       editor.updateToken(props.claim.token())
     }
-  }, [props.open, editor]);
+  }, [props.claim, props.open, editor]);
 
   return (
     <>

--- a/components/claim/ClaimFooter.tsx
+++ b/components/claim/ClaimFooter.tsx
@@ -18,6 +18,9 @@ export const ClaimFooter = (props: Props) => {
   const stakeAgree = isComment && props.claim.votes().agreement !== 0 ? true : false;
   const stakeDisagree = isComment && props.claim.votes().disagreement !== 0 ? true : false;
 
+  const textAgree = props.claim.votes().agreement.toFixed(2) + " " + token;
+  const textDisagree = props.claim.votes().disagreement.toFixed(2) + " " + token;
+
   return (
     <div className="flex mt-2 px-2">
       <div className="flex-1 w-full">
@@ -25,19 +28,21 @@ export const ClaimFooter = (props: Props) => {
           <div className="grid place-content-start">
             {isClaim && (
               <BaseButton
+                effect={true}
                 font="font-normal"
                 icon={<TriangleUpIcon className="mb-[1px]" />}
                 position="right"
-                text={`${props.claim.votes().agreement.toFixed(2)} ${token}`}
+                text={textAgree}
               />
             )}
 
             {stakeAgree && (
               <NoButton
+                effect={true}
                 font="font-normal"
                 icon={<TriangleUpIcon className="mb-[1px]" />}
                 position="right"
-                text={`${props.claim.votes().agreement.toFixed(2)} ${token}`}
+                text={textAgree}
               />
             )}
           </div>
@@ -57,19 +62,21 @@ export const ClaimFooter = (props: Props) => {
           <div className="grid place-content-end">
             {isClaim && (
               <BaseButton
+                effect={true}
                 font="font-normal"
                 icon={<TriangleDownIcon className="mb-[1px]" />}
                 position="left"
-                text={`${props.claim.votes().disagreement.toFixed(2)} ${token}`}
+                text={textDisagree}
               />
             )}
 
             {stakeDisagree && (
               <NoButton
+                effect={true}
                 font="font-normal"
                 icon={<TriangleDownIcon className="mb-[1px]" />}
                 position="left"
-                text={`${props.claim.votes().disagreement.toFixed(2)} ${token}`}
+                text={textDisagree}
               />
             )}
           </div>

--- a/components/claim/ClaimFooterCard.tsx
+++ b/components/claim/ClaimFooterCard.tsx
@@ -4,6 +4,7 @@ import * as HoverCard from "@radix-ui/react-hover-card";
 import * as Separator from "@/components/layout/separator";
 
 import { ClaimObject } from "@/modules/claim/object/ClaimObject";
+import { EffectButton } from "@/components/button/EffectButton";
 
 interface Props {
   claim: ClaimObject;
@@ -27,10 +28,14 @@ export const ClaimFooterCard = (props: Props) => {
       closeDelay={500}
       openDelay={250}
     >
-      <HoverCard.Trigger asChild>
-        <div className="p-2 text-gray-400 dark:text-gray-500 underline underline-offset-4 decoration-dashed cursor-default">
-          {`${probability} %`}
-        </div>
+      <HoverCard.Trigger className="text-gray-400 dark:text-gray-500">
+        <EffectButton
+          value={probability}
+        >
+          <div className="underline underline-offset-4 decoration-dashed cursor-default">
+            {`${probability} %`}
+          </div>
+        </EffectButton>
       </HoverCard.Trigger>
       <HoverCard.Portal>
         <HoverCard.Content

--- a/components/claim/ClaimHeader.tsx
+++ b/components/claim/ClaimHeader.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import Link from "next/link";
 
 import * as ToastSender from "@/components/toast/ToastSender";
@@ -26,7 +27,12 @@ export const ClaimHeader = (props: Props) => {
       >
         {image !== "" && (
           <Link href={"/user/" + props.claim.owner().id()}>
-            <img src={image} />
+            <Image
+              alt={props.claim.owner().name()}
+              src={image}
+              width={48}
+              height={48}
+            />
           </Link>
         )}
       </div>

--- a/components/claim/ClaimList.tsx
+++ b/components/claim/ClaimList.tsx
@@ -60,7 +60,7 @@ export const ClaimList = (props: Props) => {
   // that search queries are automatically extended at the moment in order to
   // provide claims with comments and comments with their parent claims. This
   // automatic extension is the reason for our filtering efforts here.
-  const list = getLis(claims.data, votes.data, props.page || "");
+  const list = getLis(claims.data || [], votes.data || [], props.page || "");
 
   // We want to embed claims on comment posts on basically every page, except on
   // the claim page where we show claims and their comments underneath. So if we
@@ -98,16 +98,19 @@ export const ClaimList = (props: Props) => {
   );
 };
 
-const getLis = (cla: ClaimObject[] | undefined, vot: VoteObject[] | undefined, pag: string): ClaimObject[] => {
-  if (cla && pag) return ordPos(cla, pag);
-  if (cla && !vot) return cla;
-  if (cla && vot) return mrgLis(cla, vot);
-  return [];
+const getLis = (cla: ClaimObject[], vot: VoteObject[], pag: string): ClaimObject[] => {
+  cla = ordPos(cla, pag);
+  cla = mrgLis(cla, vot);
+  return cla;
 };
 
 // mrgLis produces a new array of updated claim objects according to the
 // matching vote objects as provided.
 const mrgLis = (cla: ClaimObject[], vot: VoteObject[]): ClaimObject[] => {
+  if (!vot || vot.length === 0) {
+    return cla;
+  }
+
   const map: Map<string, VoteObject[]> = new Map();
 
   for (const x of vot) {
@@ -135,6 +138,10 @@ const mrgLis = (cla: ClaimObject[], vot: VoteObject[]): ClaimObject[] => {
 // ordPos ensures the order of post objects according to the page we are
 // supposed to render.
 const ordPos = (cla: ClaimObject[], pag: string): ClaimObject[] => {
+  if (!pag || pag === "") {
+    return cla;
+  }
+
   for (const x of cla) {
     if (x.kind() === "comment" && x.id() === pag) {
       return [x];
@@ -147,10 +154,6 @@ const ordPos = (cla: ClaimObject[], pag: string): ClaimObject[] => {
       lis.push(x);
       break;
     }
-  }
-
-  if (lis.length === 0) {
-    return cla;
   }
 
   for (const x of cla) {

--- a/components/icon/BaseIcon.tsx
+++ b/components/icon/BaseIcon.tsx
@@ -3,7 +3,6 @@ import * as React from "react";
 interface Props {
   children: React.ReactNode;
   className?: string;
-  colour?: string;
   disabled?: boolean;
   onClick?: () => void;
   overwrite?: boolean;
@@ -15,7 +14,6 @@ interface Props {
 export const BaseIcon = (props: Props) => {
   const defaultClassName = `
     ${props.size ? props.size : "w-5 h-5"}
-    ${props.colour ? props.colour : "text-gray-400 dark:text-gray-500"}
     ${props.disabled ? "opacity-80" : "group-hover:text-black dark:group-hover:text-white"}
   `;
 

--- a/components/icon/TriangleDownIcon.tsx
+++ b/components/icon/TriangleDownIcon.tsx
@@ -2,7 +2,6 @@ import { BaseIcon } from "@/components/icon/BaseIcon";
 
 interface Props {
   className?: string;
-  colour?: string;
   size?: string;
 }
 
@@ -11,7 +10,6 @@ export const TriangleDownIcon = (props: Props) => {
   return (
     <BaseIcon
       className={props.className}
-      colour={props.colour}
       size={props.size}
       viewBox="0 -960 960 960"
     >

--- a/components/icon/TriangleUpIcon.tsx
+++ b/components/icon/TriangleUpIcon.tsx
@@ -2,7 +2,6 @@ import { BaseIcon } from "@/components/icon/BaseIcon";
 
 interface Props {
   className?: string;
-  colour?: string;
   size?: string;
 }
 
@@ -11,7 +10,6 @@ export const TriangleUpIcon = (props: Props) => {
   return (
     <BaseIcon
       className={props.className}
-      colour={props.colour}
       size={props.size}
       viewBox="0 -960 960 960"
     >

--- a/components/sidebar/button/ControlButton.tsx
+++ b/components/sidebar/button/ControlButton.tsx
@@ -10,7 +10,7 @@ export const ControlButton = (props: Props) => {
   return (
     <button
       className={`
-        p-2 h-fit items-center rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700 outline-none group
+        p-2 h-fit items-center rounded hover:bg-gray-200 dark:hover:bg-gray-700 outline-none group
         ${props.className}
       `}
       onClick={props.onClick}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,14 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: false,
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "picsum.photos",
+      },
+    ],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
This was an idea that I wanted to waste my own time on. Don't know why I am doing this to myself all the time, but in the end I liked the result quite a bit. The problem with the state update is, that when you stake reputation, then the numbers get updated so quickly that the user does not really notice what is happening, or, that anything is happening at all.

The animation implemented here adds and removes a simple CSS class, which defines a rather normal animation, meaning that most of the devices out there should be able to render the state changes accurately. No fancy bullshit, just a subtle pulse of font color change indicating that something is in fact happening. The icon outlines and dashed underline of the probability indicator are all animated, as well as the percentage of either side of the bet.

https://github.com/user-attachments/assets/1c369979-6c9e-4568-8271-1e532e086178