### PR TITLE
add initial loading page

### DIFF
--- a/app/claim/[slug]/comment/layout.tsx
+++ b/app/claim/[slug]/comment/layout.tsx
@@ -4,6 +4,6 @@ export default function Layout({ children }: { children: React.ReactNode }) {
   return (
     <AuthPage>
       {children}
-    </AuthPage >
+    </AuthPage>
   );
 };

--- a/app/claim/[slug]/comment/page.tsx
+++ b/app/claim/[slug]/comment/page.tsx
@@ -10,6 +10,7 @@ import { MarkdownField } from "@/components/app/claim/comment/field/MarkdownFiel
 import { MarkdownPreview } from "@/components/app/claim/comment/preview/MarkdownPreview";
 import { PageButton } from "@/components/page/PageButton";
 import { PostSearch } from "@/modules/api/post/search/Search";
+import { QueryStore } from "@/modules/query/QueryStore";
 import { SubmitButton } from "@/components/app/claim/comment/editor/SubmitButton";
 import { useQuery } from "@tanstack/react-query";
 
@@ -17,8 +18,9 @@ export default function Page({ params }: { params: { slug: string } }) {
   const [edit, setEdit] = React.useState<boolean>(true);
 
   const editor = EditorStore.getState();
+  const query = QueryStore.getState().query;
 
-  const claim = useQuery({
+  const posts = useQuery({
     queryKey: ["claim", params.slug, "comment", "PostSearch"],
     queryFn: async () => {
       const pos = await PostSearch("", [{ id: params.slug }]);
@@ -33,7 +35,7 @@ export default function Page({ params }: { params: { slug: string } }) {
         }
       }
     },
-  })
+  }, query.client)
 
   React.useEffect(() => {
     editor.updateClaim(params.slug)
@@ -41,13 +43,13 @@ export default function Page({ params }: { params: { slug: string } }) {
 
   return (
     <>
-      {!claim.data && (
+      {!posts.data && (
         <>
           claim not found
         </>
       )}
 
-      {claim.data && (
+      {posts.data && (
         <>
           <div className="flex mb-6 w-full items-center">
             <PageButton
@@ -70,7 +72,7 @@ export default function Page({ params }: { params: { slug: string } }) {
           )}
 
           <ClaimPreview
-            claim={claim.data}
+            claim={posts.data}
           />
 
           <div className="grid place-content-end">

--- a/app/claim/propose/layout.tsx
+++ b/app/claim/propose/layout.tsx
@@ -4,6 +4,6 @@ export default function Layout({ children }: { children: React.ReactNode }) {
   return (
     <AuthPage>
       {children}
-    </AuthPage >
+    </AuthPage>
   );
 };

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,44 +1,38 @@
-"use client";
-
 import "@/app/effects.css";
 import "@/app/globals.css";
 
-import { AppProvider } from "@/components/app/AppProvider";
 import { Inter } from "next/font/google";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { LoadingPage } from "@/components/loading/LoadingPage";
+import { Metadata } from "next";
+import type { Viewport } from "next";
 
 const inter = Inter({ subsets: ["latin"] });
-const query = new QueryClient();
+
+export const metadata: Metadata = {
+  title: "Uvio | See What's Real",
+  description: "Uvio is the social network for prediction markets!",
+  keywords: ["prediction market", "social network"],
+}
+
+export const viewport: Viewport = {
+  themeColor: [
+    { media: "(prefers-color-scheme: dark)", color: "#000000" },
+    { media: "(prefers-color-scheme: light)", color: "#ffffff" },
+  ],
+}
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <html className="min-h-screen" lang="en">
+    <html className="min-h-screen dark" lang="en">
       {/*
       Note that the body element will receive either the "light" or "dark" class
       based on the chosen theme.
       */}
       <body className={`min-h-screen ${inter.className}`}>
 
-        <QueryClientProvider client={query}>
-          <AppProvider />
-
-          <div className="py-4 px-2 background justify-items-center">
-            <div className="m-auto w-full max-w-xl">
-              {/*
-            The div below works together with the Sidebar component to ensure
-            that no main element within the page is hidden during media query
-            transitions. Therefore this div applies a margin on the left side in
-            order to shift the page content slightly to the right between screen
-            width of 1024px and 1120px.
-            */}
-              <div className="min-[1024px]:ml-12 min-[1120px]:ml-0">
-
-                {children}
-
-              </div>
-            </div>
-          </div >
-        </QueryClientProvider>
+        <LoadingPage>
+          {children}
+        </LoadingPage>
 
       </body>
     </html>

--- a/app/wallet/contract/layout.tsx
+++ b/app/wallet/contract/layout.tsx
@@ -4,6 +4,6 @@ export default function Layout({ children }: { children: React.ReactNode }) {
   return (
     <AuthPage>
       {children}
-    </AuthPage >
+    </AuthPage>
   );
 };

--- a/app/wallet/contract/layout.tsx
+++ b/app/wallet/contract/layout.tsx
@@ -1,0 +1,9 @@
+import { AuthPage } from "@/components/auth/AuthPage";
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <AuthPage>
+      {children}
+    </AuthPage >
+  );
+};

--- a/app/wallet/contract/page.tsx
+++ b/app/wallet/contract/page.tsx
@@ -8,6 +8,7 @@ import * as ToastSender from "@/components/toast/ToastSender";
 import { BaseButton } from "@/components/button/BaseButton";
 import { ChainStore } from "@/modules/chain/ChainStore";
 import { CopyIcon } from "@/components/icon/CopyIcon";
+import { LoadingStore } from "@/components/loading/LoadingStore";
 import { OpenLinkIcon } from "@/components/icon/OpenLinkIcon";
 import { PageButton } from "@/components/page/PageButton";
 import { RefreshIcon } from "@/components/icon/RefreshIcon";
@@ -26,6 +27,16 @@ export default function Page() {
   const onClick = () => {
     ToastSender.Info("It's comming just chill ok!");
   };
+
+  {
+    const { loaded, loading } = LoadingStore();
+
+    React.useEffect(() => {
+      loaded();
+    }, []);
+
+    if (loading) return <></>;
+  }
 
   return (
     <>

--- a/components/app/AppProvider.tsx
+++ b/components/app/AppProvider.tsx
@@ -30,8 +30,8 @@ export const AppProvider = () => {
           supportedChains: chain.getAll(),
         }}
       >
-        <Sidebar />
         <AuthProvider />
+        <Sidebar />
       </PrivyProvider >
 
       <ToastProvider />

--- a/components/auth/AuthPage.tsx
+++ b/components/auth/AuthPage.tsx
@@ -2,13 +2,21 @@
 
 import * as React from "react";
 
+import { LoadingStore } from "@/components/loading/LoadingStore";
 import { UserStore } from "@/modules/user/UserStore";
 import { useShallow } from "zustand/react/shallow";
 
 export const AuthPage = ({ children }: { children: React.ReactNode }) => {
+  const { authorizing, loaded, loading } = LoadingStore();
   const { valid } = UserStore(useShallow((state) => ({
     valid: state.user.valid,
   })));
+
+  React.useEffect(() => {
+    loaded();
+  }, []);
+
+  if (loading || authorizing) return <></>;
 
   return (
     <>
@@ -17,9 +25,13 @@ export const AuthPage = ({ children }: { children: React.ReactNode }) => {
           {children}
         </div>
       ) : (
-        <div>
-          You need to login to see this page.
-        </div>
+        <>
+          {!authorizing && (
+            <div>
+              You need to login to see this page.
+            </div>
+          )}
+        </>
       )}
     </>
   );

--- a/components/auth/AuthPage.tsx
+++ b/components/auth/AuthPage.tsx
@@ -13,8 +13,10 @@ export const AuthPage = ({ children }: { children: React.ReactNode }) => {
   })));
 
   React.useEffect(() => {
-    loaded();
-  }, []);
+    if (!authorizing) {
+      loaded();
+    }
+  }, [authorizing]);
 
   if (loading || authorizing) return <></>;
 

--- a/components/auth/AuthProvider.tsx
+++ b/components/auth/AuthProvider.tsx
@@ -115,11 +115,11 @@ const setupAuth = async (user: Privy.User, signer: Privy.ConnectedWallet) => {
     // wallets depends on the user object being properly prepared and available.
     {
       await EnsureUser(address, token);
+      LoadingStore.getState().authorized();
       await EnsureWallets(contract, signer, token);
     }
 
     {
-      LoadingStore.getState().authorized();
       console.log("AuthProvider.setupAuth");
     }
   } catch (err) {

--- a/components/loading/LoadingPage.tsx
+++ b/components/loading/LoadingPage.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import * as React from "react";
+
+import { AppLogo } from "@/components/app/AppLogo";
+import { AppProvider } from "@/components/app/AppProvider";
+import { LoadingStore } from "@/components/loading/LoadingStore";
+
+export const LoadingPage = ({ children }: { children: React.ReactNode }) => {
+  const { loading } = LoadingStore();
+
+  return (
+    <>
+      <AppProvider />
+
+      {loading ? (
+        <div className="flex items-center justify-center min-h-screen">
+          <AppLogo />
+          {children}
+        </div>
+      ) : (
+        <div className="py-4 px-2 background justify-items-center">
+          <div className="m-auto h-full w-full max-w-xl">
+            {/*
+            The div below works together with the Sidebar component to ensure
+            that no main element within the page is hidden during media query
+            transitions. Therefore this div applies a margin on the left side in
+            order to shift the page content slightly to the right between screen
+            width of 1024px and 1120px.
+            */}
+            <div className="min-[1024px]:ml-12 min-[1120px]:ml-0">
+
+              {children}
+
+            </div>
+          </div>
+        </div >
+      )}
+    </>
+  );
+};

--- a/components/loading/LoadingStore.tsx
+++ b/components/loading/LoadingStore.tsx
@@ -1,0 +1,27 @@
+import { create } from "zustand";
+import { combine } from "zustand/middleware";
+
+export const LoadingStore = create(
+  combine(
+    {
+      authorizing: true,
+      loading: true,
+    },
+    (set) => ({
+      authorized: () => {
+        set(() => {
+          return {
+            authorizing: false,
+          };
+        });
+      },
+      loaded: () => {
+        set(() => {
+          return {
+            loading: false,
+          };
+        });
+      },
+    })
+  )
+);

--- a/components/page/PageButton.tsx
+++ b/components/page/PageButton.tsx
@@ -1,5 +1,7 @@
 import * as Separator from "@/components/page/separator";
 
+import { LoadingStore } from "@/components/loading/LoadingStore";
+
 interface Props {
   active: boolean;
   onClick: () => void;
@@ -7,6 +9,10 @@ interface Props {
 }
 
 export const PageButton = (props: Props) => {
+  const { loading } = LoadingStore();
+
+  if (loading) return <></>;
+
   return (
     <button
       className={`

--- a/components/page/PageHeader.tsx
+++ b/components/page/PageHeader.tsx
@@ -1,8 +1,14 @@
+import { LoadingStore } from "@/components/loading/LoadingStore";
+
 interface Props {
   titl: string;
 }
 
 export const PageHeader = (props: Props) => {
+  const { loading } = LoadingStore();
+
+  if (loading) return <></>;
+
   return (
     <h3 className="mb-4 text-right text-3xl">
       {props.titl}

--- a/components/sidebar/Sidebar.tsx
+++ b/components/sidebar/Sidebar.tsx
@@ -7,6 +7,7 @@ import { AppLogo } from "@/components/app/AppLogo";
 import { AuthButton } from "@/components/sidebar/button/AuthButton";
 import { BarsLeftIcon } from "@/components/icon/BarsLeftIcon";
 import { BaseButton } from "@/components/button/BaseButton";
+import { LoadingStore } from "@/components/loading/LoadingStore";
 import { ProposeButton } from "@/components/sidebar/button/ProposeButton";
 import { SocialButton } from "@/components/sidebar/button/SocialButton";
 import { ThemeButton } from "@/components/sidebar/button/ThemeButton";
@@ -42,6 +43,12 @@ export const Sidebar = () => {
       qry.removeEventListener("change", onChange);
     };
   }, []);
+
+  {
+    const { loading } = LoadingStore();
+
+    if (loading) return <></>;
+  }
 
   return (
     <div

--- a/modules/query/QueryStore.tsx
+++ b/modules/query/QueryStore.tsx
@@ -1,20 +1,34 @@
 import { create } from "zustand";
 import { combine } from "zustand/middleware";
+import { QueryClient } from "@tanstack/react-query";
 
-export interface ClaimMessage {
+export interface RefreshMessage {
   refresh: () => void;
+};
+
+export interface QueryMessage {
+  client: QueryClient;
+};
+
+const newQueryMessage = (): QueryMessage => {
+  return {
+    client: new QueryClient(),
+  };
 };
 
 export const QueryStore = create(
   combine(
     {
-      claim: {} as ClaimMessage,
+      claim: {} as RefreshMessage,
+      query: newQueryMessage(),
     },
     (set) => ({
-      updateClaim: (c: ClaimMessage) => {
+      updateClaim: (f: () => void) => {
         set(() => {
           return {
-            claim: c,
+            claim: {
+              refresh: f,
+            },
           };
         });
       },


### PR DESCRIPTION
Towards https://github.com/uvio-network/issues/issues/15. Initially I only wanted to add stupid site meta data. And I ended up restructuring the whole page loading process because of that mess that is client and server components and my lack of understanding thereof. Anyway, we have a nice loading page now, which makes the rendering less spotty for the user. We also have site meta data now and the layout structure in our code is a bit nicer. All of that comes at the cost of more complexity in scheduling and signalling the desired loading and authentication state across components. 

<img width="170" alt="Screenshot 2024-08-18 at 19 30 22" src="https://github.com/user-attachments/assets/3353cb4d-f7cd-43eb-9a9e-97d29a9ff217">

---

<img width="643" alt="Screenshot 2024-08-18 at 19 28 28" src="https://github.com/user-attachments/assets/0c76fa46-5211-4b99-b2b6-6bffb383946c">
