### PR TITLE
sync theme buttons with system theme changes

### DIFF
--- a/components/sidebar/button/ThemeButton.tsx
+++ b/components/sidebar/button/ThemeButton.tsx
@@ -86,9 +86,13 @@ export const ThemeButton = () => {
     }
   }, []);
 
+  if (!mntd) {
+    return <></>;
+  }
+
   return (
     <>
-      {mntd && them == thmDrk && (
+      {them == thmDrk && (
         <BaseButton
           onClick={() => {
             localStorage.setItem(thmKey, thmSys);
@@ -99,7 +103,7 @@ export const ThemeButton = () => {
         />
       )}
 
-      {mntd && them == thmSys && (
+      {them == thmSys && syst === thmDrk && (
         <BaseButton
           onClick={() => {
             localStorage.setItem(thmKey, thmLgt);
@@ -110,7 +114,18 @@ export const ThemeButton = () => {
         />
       )}
 
-      {mntd && them == thmLgt && (
+      {them == thmSys && syst === thmLgt && (
+        <BaseButton
+          onClick={() => {
+            localStorage.setItem(thmKey, thmDrk);
+            setThem(thmDrk);
+          }}
+          icon={<ThemeDarkIcon />}
+          text="Dark Mode"
+        />
+      )}
+
+      {them == thmLgt && (
         <BaseButton
           onClick={() => {
             localStorage.setItem(thmKey, thmDrk);


### PR DESCRIPTION
Closes https://github.com/uvio-network/issues/issues/62. This here is not quite what the issue talked about, but I started thinking that the idea from the issue is simply not possible. What we achieve here though is to remove this unnecessary step of switching twice. Now the other theme is always only one click away. 