### PR TITLE
ensure lifecycle label height

### DIFF
--- a/components/label/BaseLabel.tsx
+++ b/components/label/BaseLabel.tsx
@@ -11,7 +11,7 @@ export const BaseLabel = (props: Props) => {
   return (
     <div
       className={TrimWhitespace(`
-        w-fit px-1 py-[1px] rounded
+        w-fit h-fit px-1 py-[1px] rounded
         text-sm font-mono font-medium border whitespace-nowrap
         ${props.dashed === true ? "border-dashed" : ""}
         ${props.className ? props.className : ""}


### PR DESCRIPTION
Saw this on narrow mobile screens.

<img width="332" alt="Screenshot 2024-11-15 at 18 24 40" src="https://github.com/user-attachments/assets/5f44a70b-7ccb-4cd9-b4b3-8a28d0c21296">
